### PR TITLE
option to disable flexbox for a column

### DIFF
--- a/src/components/DateInput/__snapshots__/test.js.snap
+++ b/src/components/DateInput/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ exports[`DateInput matches snapshot: enzyme.mount 1`] = `
         >
           <glamorous(label)>
             <label
-              className="css-1dyhx6n"
+              className="css-16y5nda"
             >
               <glamorous(span)>
                 <span
@@ -49,7 +49,7 @@ exports[`DateInput matches snapshot: enzyme.mount 1`] = `
           </glamorous(label)>
           <glamorous(label)>
             <label
-              className="css-1dyhx6n"
+              className="css-16y5nda"
             >
               <glamorous(span)>
                 <span
@@ -72,7 +72,7 @@ exports[`DateInput matches snapshot: enzyme.mount 1`] = `
             className="year"
           >
             <label
-              className="css-1dyhx6n year"
+              className="css-16y5nda year"
             >
               <glamorous(span)>
                 <span
@@ -113,7 +113,7 @@ exports[`DateInput matches snapshot: enzyme.render 1`] = `
     class="css-m5vkn2"
   >
     <label
-      class="css-1dyhx6n"
+      class="css-16y5nda"
     >
       <span
         class="css-1m1nyko"
@@ -126,7 +126,7 @@ exports[`DateInput matches snapshot: enzyme.render 1`] = `
       />
     </label>
     <label
-      class="css-1dyhx6n"
+      class="css-16y5nda"
     >
       <span
         class="css-1m1nyko"
@@ -139,7 +139,7 @@ exports[`DateInput matches snapshot: enzyme.render 1`] = `
       />
     </label>
     <label
-      class="css-1dyhx6n year"
+      class="css-16y5nda year"
     >
       <span
         class="css-1m1nyko"

--- a/src/components/FileUpload/__snapshots__/test.js.snap
+++ b/src/components/FileUpload/__snapshots__/test.js.snap
@@ -10,7 +10,7 @@ exports[`FileUpload matches snapshot: enzyme.mount 1`] = `
     errorText={null}
   >
     <label
-      className="css-1dyhx6n"
+      className="css-16y5nda"
     >
       <glamorous(span)
         errorText={null}
@@ -49,7 +49,7 @@ exports[`FileUpload matches snapshot: enzyme.mount 1`] = `
 
 exports[`FileUpload matches snapshot: enzyme.render 1`] = `
 <label
-  class="css-1dyhx6n"
+  class="css-16y5nda"
 >
   <span
     class="css-1m1nyko"

--- a/src/components/GridCol/index.js
+++ b/src/components/GridCol/index.js
@@ -8,6 +8,9 @@ import { GUTTER_HALF, MEDIA_QUERIES } from "../../constants/index";
 
 const GridColInner = glamorous.div(
   {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
     backgroundColor: "transparent",
     backgroundImage: "none",
     marginBottom: "0",
@@ -43,6 +46,11 @@ const GridColInner = glamorous.div(
     [MEDIA_QUERIES.LARGESCREEN]: {
       width: columnOneQuarter ? "50%" : GridColInner.width
     }
+  }),
+  ({ noFlex }) => ({
+    display: noFlex ? "block" : GridColInner.display,
+    flexDirection: noFlex ? "unset" : GridColInner.flexDirection,
+    alignItems: noFlex ? "unset" : GridColInner.alignItems
   })
 );
 

--- a/src/components/InputField/__snapshots__/test.js.snap
+++ b/src/components/InputField/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`InputField matches snapshot: enzyme.mount 1`] = `
 >
   <glamorous(label)>
     <label
-      className="css-1dyhx6n"
+      className="css-16y5nda"
     >
       <glamorous(span)>
         <span
@@ -32,7 +32,7 @@ exports[`InputField matches snapshot: enzyme.mount 1`] = `
 
 exports[`InputField matches snapshot: enzyme.render 1`] = `
 <label
-  class="css-1dyhx6n"
+  class="css-16y5nda"
 >
   <span
     class="css-1m1nyko"

--- a/src/components/Label/__snapshots__/test.js.snap
+++ b/src/components/Label/__snapshots__/test.js.snap
@@ -3,7 +3,7 @@
 exports[`Label matches snapshot: enzyme.mount 1`] = `
 <glamorous(label)>
   <label
-    className="css-1dyhx6n"
+    className="css-16y5nda"
   >
     example
   </label>
@@ -12,7 +12,7 @@ exports[`Label matches snapshot: enzyme.mount 1`] = `
 
 exports[`Label matches snapshot: enzyme.render 1`] = `
 <label
-  class="css-1dyhx6n"
+  class="css-16y5nda"
 >
   example
 </label>
@@ -20,7 +20,7 @@ exports[`Label matches snapshot: enzyme.render 1`] = `
 
 exports[`Label matches snapshot: enzyme.shallow 1`] = `
 <label
-  className="css-1dyhx6n"
+  className="css-16y5nda"
 >
   example
 </label>

--- a/src/components/Label/index.js
+++ b/src/components/Label/index.js
@@ -10,6 +10,7 @@ const Label = glamorous.label(
     display: "flex",
     flexDirection: "column",
     boxSizing: "border-box",
+    width: "100%",
     [MEDIA_QUERIES.LARGESCREEN]: {
       maxWidth: SITE_WIDTH
     }

--- a/src/components/Select/__snapshots__/test.js.snap
+++ b/src/components/Select/__snapshots__/test.js.snap
@@ -10,7 +10,7 @@ exports[`Select matches snapshot: enzyme.mount 1`] = `
     errorText={null}
   >
     <label
-      className="css-1dyhx6n"
+      className="css-16y5nda"
     >
       <glamorous(span)
         errorText={null}
@@ -39,7 +39,7 @@ exports[`Select matches snapshot: enzyme.mount 1`] = `
 
 exports[`Select matches snapshot: enzyme.render 1`] = `
 <label
-  class="css-1dyhx6n"
+  class="css-16y5nda"
 >
   <span
     class="css-1m1nyko"

--- a/src/components/TextArea/__snapshots__/test.js.snap
+++ b/src/components/TextArea/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`Textarea matches snapshot: enzyme.mount 1`] = `
 >
   <glamorous(label)>
     <label
-      className="css-1dyhx6n"
+      className="css-16y5nda"
     >
       <glamorous(span)>
         <span
@@ -33,7 +33,7 @@ exports[`Textarea matches snapshot: enzyme.mount 1`] = `
 
 exports[`Textarea matches snapshot: enzyme.render 1`] = `
 <label
-  class="css-1dyhx6n"
+  class="css-16y5nda"
 >
   <span
     class="css-1m1nyko"


### PR DESCRIPTION
Suggestion to have columns `display: flex` (column) by default and have the ability to disable flexbox for a certain columns.

Currently:
1. columns are set to display:block
2. some children have floated elements (such as radios with prop of `inline`) which requires fixing the clearing (such as `overflow:hidden`, which isn't great if `drop-shadow` or `outline` is used outside of the box)
3. labels are being used in a block-level way for each line, which by default stretch to 100%
4. whitespace of labels are clickable, which can allow a checkbox to be accidentally clicked 
![before](https://user-images.githubusercontent.com/1695055/35623534-d62b2bdc-0683-11e8-9542-d4edc3db199a.gif)

What I'm proposing to happen is:
1. have just the checkbox/label clickable (so the label is effectively inline, but clears each line as if it were block) (using `display:flex` and `align-items: flex-start`
![after](https://user-images.githubusercontent.com/1695055/35623178-6f1f0b80-0682-11e8-9ee0-787636d656e3.gif)
2. floated elements dont float inside a flexbox, so to make them float we would pass a prop to set the display to block, allowing children to float
![screen shot 2018-01-31 at 12 43 19](https://user-images.githubusercontent.com/1695055/35623672-56cdf88c-0684-11e8-8be1-09b5ecae9803.png)
