### PR TITLE
npm deploy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ deploy:
   - provider: npm
     email: $NPM_EMAIL
     api_key: $NPM_TOKEN
+    skip_cleanup: true
     on:
       tags: true
   - provider: releases


### PR DESCRIPTION
skip cleanup for npm deploys as node_modules folder is needed to execute publish