### PR TITLE
Feature/api docs table

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ BackLink
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | Generally the text that will appear in the back link
+ `children` | true |  | node | Generally the text that will appear in the back link
  `goBack` |  | undefined | func | A function that is called on click
 
 
@@ -22,7 +22,7 @@ Breadcrumb
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | Generally a series of anchors or Link components
+ `children` | true |  | node | Generally a series of anchors or Link components
 
 
 Button
@@ -48,7 +48,7 @@ Checkbox
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `inline` |  | undefined | bool | 
 
 
@@ -62,7 +62,7 @@ DateInput
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `errorText` |  | null | string | 
  `hintText` |  | null | string | 
 
@@ -85,7 +85,7 @@ FileUpload
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
  `acceptedFormats` |  | null | string | 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `hint` |  | null | string | 
  `meta` |  | {} | shape[object Object] | 
 
@@ -113,7 +113,7 @@ GridRow
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
 
 
 Header
@@ -162,7 +162,7 @@ InputField
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `hint` |  | null | string | 
  `input` |  | {} | shape[object Object] | 
  `meta` |  | {} | shape[object Object] | 
@@ -192,7 +192,7 @@ Layout
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
 
 
 MultiChoice
@@ -205,9 +205,9 @@ MultiChoice
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `hint` |  | undefined | string | 
- `label` | true | N/A | node | 
+ `label` | true |  | node | 
  `meta` |  | {} | shape[object Object] | 
 
 
@@ -228,8 +228,8 @@ PhaseBanner
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
- `level` | true | N/A | string | 
+ `children` | true |  | node | 
+ `level` | true |  | string | 
 
 
 Radio
@@ -242,7 +242,7 @@ Radio
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `inline` |  | undefined | bool | 
 
 
@@ -256,11 +256,11 @@ Select
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `errorText` |  | null | string | 
  `hint` |  | undefined | string | 
  `input` |  | {} | shape[object Object] | 
- `label` | true | N/A | string | 
+ `label` | true |  | string | 
  `meta` |  | {} | shape[object Object] | 
 
 
@@ -274,7 +274,7 @@ TextArea
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
- `children` | true | N/A | node | 
+ `children` | true |  | node | 
  `hint` |  | null | string | 
  `input` |  | {} | shape[object Object] | 
  `meta` |  | {} | shape[object Object] | 

--- a/API.md
+++ b/API.md
@@ -4,10 +4,8 @@ BackLink
 ![Component Image](./docs/BackLink.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | Generally the text that will appear in the back link
  `goBack` |  | undefined | func | A function that is called on click
 
@@ -18,10 +16,8 @@ Breadcrumb
 ![Component Image](./docs/Breadcrumb.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | Generally a series of anchors or Link components
 
 
@@ -31,10 +27,8 @@ Button
 ![Component Image](./docs/Button.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` |  | "Button" |  | 
 
 
@@ -44,10 +38,8 @@ Checkbox
 ![Component Image](./docs/Checkbox.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `inline` |  | undefined | bool | 
 
@@ -58,10 +50,8 @@ DateInput
 ![Component Image](./docs/DateInput.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `errorText` |  | null | string | 
  `hintText` |  | null | string | 
@@ -80,10 +70,8 @@ FileUpload
 ![Component Image](./docs/FileUpload.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `acceptedFormats` |  | null | string | 
  `children` | true |  | node | 
  `hint` |  | null | string | 
@@ -96,10 +84,8 @@ GridCol
 ![Component Image](./docs/GridCol.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` |  | undefined | node | 
 
 
@@ -109,10 +95,8 @@ GridRow
 ![Component Image](./docs/GridRow.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
 
 
@@ -122,10 +106,8 @@ Header
 ![Component Image](./docs/Header.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `level` |  | 1 | number | 
  `size` |  | undefined | enumObject.keys(FONT_SIZES) | 
 
@@ -143,10 +125,8 @@ Input
 ![Component Image](./docs/Input.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `onChange` |  | undefined | func | 
  `type` |  | "text" | string | 
  `value` |  | undefined | string | 
@@ -158,10 +138,8 @@ InputField
 ![Component Image](./docs/InputField.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `hint` |  | null | string | 
  `input` |  | {} | shape[object Object] | 
@@ -188,10 +166,8 @@ Layout
 ![Component Image](./docs/Layout.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
 
 
@@ -201,10 +177,8 @@ MultiChoice
 ![Component Image](./docs/MultiChoice.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `hint` |  | undefined | string | 
  `label` | true |  | node | 
@@ -224,10 +198,8 @@ PhaseBanner
 ![Component Image](./docs/PhaseBanner.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `level` | true |  | string | 
 
@@ -238,10 +210,8 @@ Radio
 ![Component Image](./docs/Radio.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `inline` |  | undefined | bool | 
 
@@ -252,10 +222,8 @@ Select
 ![Component Image](./docs/Select.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `errorText` |  | null | string | 
  `hint` |  | undefined | string | 
@@ -270,10 +238,8 @@ TextArea
 ![Component Image](./docs/TextArea.png)
 
 
-Props
------
-Prop Name | Required | Default | Type | Description 
-:-------- | :------- | :------ | :--- | :---------- 
+Prop | Required | Default | Type | Description 
+:--- | :------- | :------ | :--- | :---------- 
  `children` | true |  | node | 
  `hint` |  | null | string | 
  `input` |  | {} | shape[object Object] | 

--- a/API.md
+++ b/API.md
@@ -4,22 +4,13 @@ BackLink
 ![Component Image](./docs/BackLink.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | Generally the text that will appear in the back link
+ `goBack` |  | undefined | func | A function that is called on click
 
-### `children` (required)
-
-Generally the text that will appear in the back link
-
-type: `node`
-
-
-### `goBack`
-
-A function that is called on click
-
-type: `func`
-defaultValue: `undefined`
 
 Breadcrumb
 ==========
@@ -27,14 +18,12 @@ Breadcrumb
 ![Component Image](./docs/Breadcrumb.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | Generally a series of anchors or Link components
 
-### `children` (required)
-
-Generally a series of anchors or Link components
-
-type: `node`
 
 Button
 ======
@@ -42,12 +31,12 @@ Button
 ![Component Image](./docs/Button.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` |  | "Button" |  | 
 
-### `children`
-
-defaultValue: `"Button"`
 
 Checkbox
 ========
@@ -55,18 +44,13 @@ Checkbox
 ![Component Image](./docs/Checkbox.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `inline` |  | undefined | bool | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `inline`
-
-type: `bool`
-defaultValue: `undefined`
 
 DateInput
 =========
@@ -74,24 +58,14 @@ DateInput
 ![Component Image](./docs/DateInput.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `errorText` |  | null | string | 
+ `hintText` |  | null | string | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `errorText`
-
-type: `string`
-defaultValue: `null`
-
-
-### `hintText`
-
-type: `string`
-defaultValue: `null`
 
 ErrorText
 =========
@@ -99,36 +73,48 @@ ErrorText
 ![Component Image](./docs/ErrorText.png)
 
 
+ 
 FileUpload
 ==========
 
 ![Component Image](./docs/FileUpload.png)
 
 
-Props
+ Props
 -----
-
-### `acceptedFormats`
-
-type: `string`
-defaultValue: `null`
-
-
-### `children` (required)
-
-type: `node`
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `acceptedFormats` |  | null | string | 
+ `children` | true | N/A | node | 
+ `hint` |  | null | string | 
+ `meta` |  | {} | shape[object Object] | 
 
 
-### `hint`
+GridCol
+=======
 
-type: `string`
-defaultValue: `null`
+![Component Image](./docs/GridCol.png)
 
 
-### `meta`
+ Props
+-----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` |  | undefined | node | 
 
-type: `shape[object Object]`
-defaultValue: `{}`
+
+GridRow
+=======
+
+![Component Image](./docs/GridRow.png)
+
+
+ Props
+-----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+
 
 Header
 ======
@@ -136,19 +122,13 @@ Header
 ![Component Image](./docs/Header.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `level` |  | 1 | number | 
+ `size` |  | undefined | enumObject.keys(FONT_SIZES) | 
 
-### `level`
-
-type: `number`
-defaultValue: `1`
-
-
-### `size`
-
-type: `enumObject.keys(FONT_SIZES)`
-defaultValue: `undefined`
 
 HintText
 ========
@@ -156,31 +136,21 @@ HintText
 ![Component Image](./docs/HintText.png)
 
 
+ 
 Input
 =====
 
 ![Component Image](./docs/Input.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `onChange` |  | undefined | func | 
+ `type` |  | "text" | string | 
+ `value` |  | undefined | string | 
 
-### `onChange`
-
-type: `func`
-defaultValue: `undefined`
-
-
-### `type`
-
-type: `string`
-defaultValue: `"text"`
-
-
-### `value`
-
-type: `string`
-defaultValue: `undefined`
 
 InputField
 ==========
@@ -188,30 +158,15 @@ InputField
 ![Component Image](./docs/InputField.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `hint` |  | null | string | 
+ `input` |  | {} | shape[object Object] | 
+ `meta` |  | {} | shape[object Object] | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `hint`
-
-type: `string`
-defaultValue: `null`
-
-
-### `input`
-
-type: `shape[object Object]`
-defaultValue: `{}`
-
-
-### `meta`
-
-type: `shape[object Object]`
-defaultValue: `{}`
 
 Label
 =====
@@ -219,10 +174,25 @@ Label
 ![Component Image](./docs/Label.png)
 
 
+ 
 LabelText
 =========
 
 ![Component Image](./docs/LabelText.png)
+
+
+ 
+Layout
+======
+
+![Component Image](./docs/Layout.png)
+
+
+ Props
+-----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
 
 
 MultiChoice
@@ -231,29 +201,15 @@ MultiChoice
 ![Component Image](./docs/MultiChoice.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `hint` |  | undefined | string | 
+ `label` | true | N/A | node | 
+ `meta` |  | {} | shape[object Object] | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `hint`
-
-type: `string`
-defaultValue: `undefined`
-
-
-### `label` (required)
-
-type: `node`
-
-
-### `meta`
-
-type: `shape[object Object]`
-defaultValue: `{}`
 
 PhaseBadge
 ==========
@@ -261,23 +217,20 @@ PhaseBadge
 ![Component Image](./docs/PhaseBadge.png)
 
 
+ 
 PhaseBanner
 ===========
 
 ![Component Image](./docs/PhaseBanner.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `level` | true | N/A | string | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `level` (required)
-
-type: `string`
 
 Radio
 =====
@@ -285,18 +238,13 @@ Radio
 ![Component Image](./docs/Radio.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `inline` |  | undefined | bool | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `inline`
-
-type: `bool`
-defaultValue: `undefined`
 
 Select
 ======
@@ -304,41 +252,17 @@ Select
 ![Component Image](./docs/Select.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `errorText` |  | null | string | 
+ `hint` |  | undefined | string | 
+ `input` |  | {} | shape[object Object] | 
+ `label` | true | N/A | string | 
+ `meta` |  | {} | shape[object Object] | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `errorText`
-
-type: `string`
-defaultValue: `null`
-
-
-### `hint`
-
-type: `string`
-defaultValue: `undefined`
-
-
-### `input`
-
-type: `shape[object Object]`
-defaultValue: `{}`
-
-
-### `label` (required)
-
-type: `string`
-
-
-### `meta`
-
-type: `shape[object Object]`
-defaultValue: `{}`
 
 TextArea
 ========
@@ -346,28 +270,13 @@ TextArea
 ![Component Image](./docs/TextArea.png)
 
 
-Props
+ Props
 -----
+Prop Name | Required | Default | Type | Description 
+:-------- | :------- | :------ | :--- | :---------- 
+ `children` | true | N/A | node | 
+ `hint` |  | null | string | 
+ `input` |  | {} | shape[object Object] | 
+ `meta` |  | {} | shape[object Object] | 
 
-### `children` (required)
-
-type: `node`
-
-
-### `hint`
-
-type: `string`
-defaultValue: `null`
-
-
-### `input`
-
-type: `shape[object Object]`
-defaultValue: `{}`
-
-
-### `meta`
-
-type: `shape[object Object]`
-defaultValue: `{}`
 

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ BackLink
 ![Component Image](./docs/BackLink.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -18,7 +18,7 @@ Breadcrumb
 ![Component Image](./docs/Breadcrumb.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -31,7 +31,7 @@ Button
 ![Component Image](./docs/Button.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -44,7 +44,7 @@ Checkbox
 ![Component Image](./docs/Checkbox.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -58,7 +58,7 @@ DateInput
 ![Component Image](./docs/DateInput.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -73,14 +73,14 @@ ErrorText
 ![Component Image](./docs/ErrorText.png)
 
 
- 
+
 FileUpload
 ==========
 
 ![Component Image](./docs/FileUpload.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -96,7 +96,7 @@ GridCol
 ![Component Image](./docs/GridCol.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -109,7 +109,7 @@ GridRow
 ![Component Image](./docs/GridRow.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -122,7 +122,7 @@ Header
 ![Component Image](./docs/Header.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -136,14 +136,14 @@ HintText
 ![Component Image](./docs/HintText.png)
 
 
- 
+
 Input
 =====
 
 ![Component Image](./docs/Input.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -158,7 +158,7 @@ InputField
 ![Component Image](./docs/InputField.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -174,21 +174,21 @@ Label
 ![Component Image](./docs/Label.png)
 
 
- 
+
 LabelText
 =========
 
 ![Component Image](./docs/LabelText.png)
 
 
- 
+
 Layout
 ======
 
 ![Component Image](./docs/Layout.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -201,7 +201,7 @@ MultiChoice
 ![Component Image](./docs/MultiChoice.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -217,14 +217,14 @@ PhaseBadge
 ![Component Image](./docs/PhaseBadge.png)
 
 
- 
+
 PhaseBanner
 ===========
 
 ![Component Image](./docs/PhaseBanner.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -238,7 +238,7 @@ Radio
 ![Component Image](./docs/Radio.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -252,7 +252,7 @@ Select
 ![Component Image](./docs/Select.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 
@@ -270,7 +270,7 @@ TextArea
 ![Component Image](./docs/TextArea.png)
 
 
- Props
+Props
 -----
 Prop Name | Required | Default | Type | Description 
 :-------- | :------- | :------ | :--- | :---------- 

--- a/scripts/docs/markdown/generateMarkdown.js
+++ b/scripts/docs/markdown/generateMarkdown.js
@@ -6,7 +6,7 @@ export default function generateMarkdown(name, reactAPI, imagePath) {
   const markdownString = `${generateTitle(name)}\n${generateDescription(
     reactAPI.description,
     imagePath
-  )}\n ${generateProps(reactAPI.props)}\n`;
+  )}\n${generateProps(reactAPI.props)}\n`;
 
   return markdownString;
 }

--- a/scripts/docs/markdown/generateMarkdown.js
+++ b/scripts/docs/markdown/generateMarkdown.js
@@ -6,7 +6,7 @@ export default function generateMarkdown(name, reactAPI, imagePath) {
   const markdownString = `${generateTitle(name)}\n${generateDescription(
     reactAPI.description,
     imagePath
-  )}\n${generateProps(reactAPI.props)}`;
+  )}\n ${generateProps(reactAPI.props)}\n`;
 
   return markdownString;
 }

--- a/scripts/docs/markdown/generateProp.js
+++ b/scripts/docs/markdown/generateProp.js
@@ -3,7 +3,7 @@ import generatePropDefaultValue from "./generatePropDefaultValue";
 
 export default function generateProp(propName, prop) {
   return ` \`${propName}\` | ${prop.required ? "true" : ""} | ${
-    prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : "N/A"
+    prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : ""
   } | ${prop.type ? generatePropType(prop.type) : ""} | ${
     prop.description ? `${prop.description}` : ""
   }`;

--- a/scripts/docs/markdown/generateProp.js
+++ b/scripts/docs/markdown/generateProp.js
@@ -2,10 +2,9 @@ import generatePropType from "./generatePropType";
 import generatePropDefaultValue from "./generatePropDefaultValue";
 
 export default function generateProp(propName, prop) {
-  return (
-    `### \`${propName}\`${prop.required ? " (required)" : ""}\n` +
-    `\n${prop.description ? `${prop.description}\n\n` : ""}${
-      prop.type ? generatePropType(prop.type) : ""
-    }${prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : ""}\n`
-  );
+  return ` \`${propName}\` | ${prop.required ? "true" : ""} | ${
+    prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : "N/A"
+  } | ${prop.type ? generatePropType(prop.type) : ""} | ${
+    prop.description ? `${prop.description}` : ""
+  }`;
 }

--- a/scripts/docs/markdown/generatePropDefaultValue.js
+++ b/scripts/docs/markdown/generatePropDefaultValue.js
@@ -1,3 +1,3 @@
 export default function generatePropDefaultValue(value) {
-  return `defaultValue: \`${value.value}\`\n`;
+  return `${value.value}`;
 }

--- a/scripts/docs/markdown/generatePropType.js
+++ b/scripts/docs/markdown/generatePropType.js
@@ -8,5 +8,5 @@ export default function generatePropType(type) {
     values = type.value;
   }
 
-  return `type: \`${type.name}${values || ""}\`\n`;
+  return `${type.name}${values || ""}`;
 }

--- a/scripts/docs/markdown/generateProps.js
+++ b/scripts/docs/markdown/generateProps.js
@@ -10,10 +10,12 @@ export default function generateProps(props) {
 
   return (
     `${title}\n${stringOfLength("-", title.length)}\n` +
-    `\n${props &&
+    `Prop Name | Required | Default | Type | Description \n` +
+    `:-------- | :------- | :------ | :--- | :---------- \n` +
+    `${props &&
       Object.keys(props)
         .sort()
         .map(propName => generateProp(propName, props[propName]))
-        .join("\n")}`
+        .join("\n")}\n\n`
   );
 }

--- a/scripts/docs/markdown/generateProps.js
+++ b/scripts/docs/markdown/generateProps.js
@@ -6,12 +6,9 @@ export default function generateProps(props) {
     return "";
   }
 
-  const title = "Props";
-
   return (
-    `${title}\n${stringOfLength("-", title.length)}\n` +
-    `Prop Name | Required | Default | Type | Description \n` +
-    `:-------- | :------- | :------ | :--- | :---------- \n` +
+    `Prop | Required | Default | Type | Description \n` +
+    `:--- | :------- | :------ | :--- | :---------- \n` +
     `${props &&
       Object.keys(props)
         .sort()


### PR DESCRIPTION
Reformatted the API docs to show a table of data rather than paragraphs

Before:
![screen shot 2018-02-28 at 19 34 17](https://user-images.githubusercontent.com/1695055/36808925-689b4fba-1cbe-11e8-9a35-1c9839b312fa.png)


After:
![screen shot 2018-02-28 at 19 33 12](https://user-images.githubusercontent.com/1695055/36808857-40a2d686-1cbe-11e8-9779-9a1cf280ebd0.png)
