### PR TITLE
don't include storybook code in coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "!components/*/src/**/example.js",
       "packages/*/src/**/*.{js,jsx}",
       "!packages/*/node_modules",
-      "!packages/storybook",
+      "!packages/storybook/**",
       "!packages/*/src/**/stories.js",
       "!packages/*/src/**/example.js"
     ],


### PR DESCRIPTION
don't include `@govuk-react/storybook` code in coverage report