### PR TITLE
added example of last breadcrumb being not a link

### DIFF
--- a/components/breadcrumb/src/__snapshots__/test.js.snap
+++ b/components/breadcrumb/src/__snapshots__/test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`breadcrumb matches snapshot: enzyme.mount 1`] = `
-.glamor-2,
-[data-glamor-2] {
+.glamor-3,
+[data-glamor-3] {
   font-family: nta, Arial, sans-serif;
   font-size: 14px;
   line-height: 16px;
@@ -11,8 +11,8 @@ exports[`breadcrumb matches snapshot: enzyme.mount 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.glamor-1,
-[data-glamor-1] {
+.glamor-2,
+[data-glamor-2] {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -71,8 +71,8 @@ exports[`breadcrumb matches snapshot: enzyme.mount 1`] = `
 }
 
 @media only screen and (min-width: 641px) {
-  .glamor-2,
-  [data-glamor-2] {
+  .glamor-3,
+  [data-glamor-3] {
     font-size: 16px;
     line-height: 20px;
   }
@@ -81,13 +81,28 @@ exports[`breadcrumb matches snapshot: enzyme.mount 1`] = `
 <Breadcrumb>
   <glamorous(div)>
     <div
-      className="glamor-2"
+      className="glamor-3"
     >
       <glamorous(ul)>
         <ul
-          className="glamor-1"
+          className="glamor-2"
         >
-          <glamorous(li)>
+          <glamorous(li)
+            key="0"
+          >
+            <li
+              className="glamor-0"
+            >
+              <a
+                href="/section"
+              >
+                Section 1
+              </a>
+            </li>
+          </glamorous(li)>
+          <glamorous(li)
+            key="1"
+          >
             <li
               className="glamor-0"
             >

--- a/components/breadcrumb/src/stories.js
+++ b/components/breadcrumb/src/stories.js
@@ -18,7 +18,7 @@ storiesOf('Breadcrumb', module).add('Three levels deep', () => (
   <Breadcrumb>
     <AnchorTag href="/section">Section 1</AnchorTag>
     <AnchorTag href="/section/sub-section">Sub-section</AnchorTag>
-    <AnchorTag href="/section/three">Three sections and a long line</AnchorTag>
+    Current page
   </Breadcrumb>
 ));
 
@@ -32,11 +32,7 @@ storiesOf('Breadcrumb', module).add(
       <BrowserRouter>
         <AnchorLink to="/section/sub-section">Sub-section</AnchorLink>
       </BrowserRouter>
-      <BrowserRouter>
-        <AnchorLink to="/section/three">
-          Three sections and a long line
-        </AnchorLink>
-      </BrowserRouter>
+      Current page
     </Breadcrumb>
   ),
 );

--- a/components/breadcrumb/src/test.js
+++ b/components/breadcrumb/src/test.js
@@ -9,7 +9,7 @@ describe('breadcrumb', () => {
   const wrapper = <Breadcrumb>{example}</Breadcrumb>;
   const wrapperMultiple = (
     <Breadcrumb>
-      {example}
+      <a href="/section">Section 1</a>
       {example}
     </Breadcrumb>
   );
@@ -26,6 +26,6 @@ describe('breadcrumb', () => {
   });
 
   it('matches snapshot', () => {
-    expect(mount(wrapper)).toMatchSnapshot('enzyme.mount');
+    expect(mount(wrapperMultiple)).toMatchSnapshot('enzyme.mount');
   });
 });


### PR DESCRIPTION
Fixes #97 

- added examples to show the current page (not being a link)