### PR TITLE
Tweak phase-banner styling

### DIFF
--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.18",
   "dependencies": {
     "@govuk-react/constants": "0.1.18",
+    "@govuk-react/phase-badge": "0.1.18",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/components/phase-banner/src/__snapshots__/test.js.snap
+++ b/components/phase-banner/src/__snapshots__/test.js.snap
@@ -5,13 +5,13 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
 [data-glamor-1] {
   border-bottom: 1px solid #bfc1c3;
   box-sizing: border-box;
+  padding-top: 10px;
   padding-bottom: 10px;
   font-family: "nta", Arial, sans-serif;
   font-weight: 400;
   text-transform: none;
   font-size: 14px;
   line-height: 1.1428571429;
-  width: 100%;
 }
 
 .glamor-1> a,
@@ -57,8 +57,8 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
 <PhaseBanner
   level="beta"
 >
-  <glamorous(p)>
-    <p
+  <glamorous(div)>
+    <div
       className="glamor-1"
     >
       <PhaseBadge>
@@ -71,7 +71,7 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
         </glamorous(strong)>
       </PhaseBadge>
       example
-    </p>
-  </glamorous(p)>
+    </div>
+  </glamorous(div)>
 </PhaseBanner>
 `;

--- a/components/phase-banner/src/index.js
+++ b/components/phase-banner/src/index.js
@@ -13,16 +13,16 @@ import {
 
 import PhaseBadge from '@govuk-react/phase-badge';
 
-const PhaseBannerInner = glamorous.p({
+const PhaseBannerInner = glamorous.div({
   borderBottom: '1px solid #bfc1c3',
   boxSizing: 'border-box',
+  paddingTop: '10px',
   paddingBottom: '10px',
   fontFamily: NTA_LIGHT,
   fontWeight: 400,
   textTransform: 'none',
   fontSize: FONT_SIZE.SIZE_14,
   lineHeight: LINE_HEIGHT.SIZE_14,
-  width: '100%',
   [MEDIA_QUERIES.LARGESCREEN]: {
     fontSize: FONT_SIZE.SIZE_16,
     lineHeight: LINE_HEIGHT.SIZE_16,


### PR DESCRIPTION
Adjusts phase-banner so it has a `margin-top: 10px` matching GDS.

Also changes it to use a `div` rather than a `p` tag, as this helps simplify styling and removes a styling oddity (`p` elements have a `-webkit-margin-before` and `-webkit-margin-after` set in user-agent stylesheet).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation N/A
* [x] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
