### PR TITLE
Fix for duff breadcrumb children

### DIFF
--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -70,7 +70,8 @@ const Breadcrumb = ({ children }) => (
     <BreadcrumbList>
       {children.length && children.map ? (
         children.map((child, i) => (
-          <BreadcrumbListItem key={child.key || i}>{child}</BreadcrumbListItem>
+          child.length || child.props ? <BreadcrumbListItem key={child.key || i}>{child}</BreadcrumbListItem>
+ : null
         ))
       ) : (
         <BreadcrumbListItem>{children}</BreadcrumbListItem>

--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -65,6 +65,7 @@ const BreadcrumbListItem = glamorous.li({
   },
 });
 
+// TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
 const Breadcrumb = ({ children }) => (
   <BreadcrumbContainer>
     <BreadcrumbList>

--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -70,8 +70,9 @@ const Breadcrumb = ({ children }) => (
     <BreadcrumbList>
       {children.length && children.map ? (
         children.map((child, i) => (
-          child.length || child.props ? <BreadcrumbListItem key={child.key || i}>{child}</BreadcrumbListItem>
- : null
+          child.length || child.props
+            ? <BreadcrumbListItem key={child.key || i}>{child}</BreadcrumbListItem>
+            : null
         ))
       ) : (
         <BreadcrumbListItem>{children}</BreadcrumbListItem>

--- a/components/breadcrumb/src/stories.js
+++ b/components/breadcrumb/src/stories.js
@@ -1,12 +1,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { BrowserRouter, Link } from 'react-router-dom';
+import { asAnchor } from '@govuk-react/hoc';
 
 import Breadcrumb from '.';
-import { asAnchor } from '@govuk-react/hoc';
 
 const AnchorTag = asAnchor('a');
 const AnchorLink = asAnchor(Link);
+
+const crumbsWithDuffChildren = [
+  <AnchorTag href="/section">Section 1</AnchorTag>,
+  '',
+  'Current page',
+];
 
 storiesOf('Breadcrumb', module).add('Component default', () => (
   <Breadcrumb>
@@ -16,9 +22,15 @@ storiesOf('Breadcrumb', module).add('Component default', () => (
 
 storiesOf('Breadcrumb', module).add('Three levels deep', () => (
   <Breadcrumb>
-    <AnchorTag href="/section">Section 1</AnchorTag>
-    <AnchorTag href="/section/sub-section">Sub-section</AnchorTag>
+    <a href="/section">Section 1</a>
+    <a href="/section/sub-section">Sub-section</a>
     Current page
+  </Breadcrumb>
+));
+
+storiesOf('Breadcrumb', module).add('Duff children', () => (
+  <Breadcrumb>
+    {crumbsWithDuffChildren}
   </Breadcrumb>
 ));
 

--- a/components/breadcrumb/src/stories.js
+++ b/components/breadcrumb/src/stories.js
@@ -8,11 +8,7 @@ import Breadcrumb from '.';
 const AnchorTag = asAnchor('a');
 const AnchorLink = asAnchor(Link);
 
-const crumbsWithDuffChildren = [
-  <AnchorTag href="/section">Section 1</AnchorTag>,
-  '',
-  'Current page',
-];
+const crumbsWithDuffChildren = [];
 
 storiesOf('Breadcrumb', module).add('Component default', () => (
   <Breadcrumb>
@@ -30,7 +26,9 @@ storiesOf('Breadcrumb', module).add('Three levels deep', () => (
 
 storiesOf('Breadcrumb', module).add('Duff children', () => (
   <Breadcrumb>
+    <AnchorTag href="/section">Section 1</AnchorTag>
     {crumbsWithDuffChildren}
+    Current page
   </Breadcrumb>
 ));
 

--- a/components/breadcrumb/src/test.js
+++ b/components/breadcrumb/src/test.js
@@ -6,10 +6,18 @@ import Breadcrumb from './';
 
 describe('breadcrumb', () => {
   const example = 'example';
+  const emptyNode = [];
   const wrapper = <Breadcrumb>{example}</Breadcrumb>;
   const wrapperMultiple = (
     <Breadcrumb>
       <a href="/section">Section 1</a>
+      {example}
+    </Breadcrumb>
+  );
+  const wrapperEmptyNode = (
+    <Breadcrumb>
+      <a href="/section">Section 1</a>
+      {emptyNode}
       {example}
     </Breadcrumb>
   );
@@ -19,10 +27,17 @@ describe('breadcrumb', () => {
     ReactDOM.render(wrapper, div);
   });
 
-  it('should render an unordered list', () => {
+  it('should render an item in unordered list', () => {
     const output = mount(wrapper);
     expect(output.find('ul')).toHaveLength(1);
+  });
+
+  it('should render multiple items in unordered list', () => {
     expect(mount(wrapperMultiple).find('ul li')).toHaveLength(2);
+  });
+
+  it('should render an unordered list without ghost/duff children', () => {
+    expect(mount(wrapperEmptyNode).find('ul li')).toHaveLength(2);
   });
 
   it('matches snapshot', () => {

--- a/components/list-navigation/src/index.js
+++ b/components/list-navigation/src/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import UnorderedList from '@govuk-react/unordered-list';
 import ListItem from '@govuk-react/list-item';
 
+// TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
 const ListNavigation = ({ children, listStyleType }) => (
   <UnorderedList listStyleType={listStyleType}>
     {children.length && children.map ? (

--- a/components/ordered-list/src/index.js
+++ b/components/ordered-list/src/index.js
@@ -33,6 +33,7 @@ const GOrderedListInner = glamorous.ol(
   }),
 );
 
+// TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
 const OrderedList = ({ children, listStyleType }) => (
   <GOrderedListInner listStyleType={listStyleType}>{children}</GOrderedListInner>
 );

--- a/components/unordered-list/src/index.js
+++ b/components/unordered-list/src/index.js
@@ -33,6 +33,8 @@ const GUnorderedList = glamorous.ul(
   }),
 );
 
+// TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
+
 // listStyleType: normal HTML property values are used here
 // e.g., listStyleType="circle", listStyleType="upper-alpha", listStyleType="none"
 const UnorderedList = ({ children, listStyleType }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,15 +3013,15 @@ component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
-component-image@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/component-image/-/component-image-1.1.0.tgz#75860c2c702d0051c764e9b0fcb0b9730cf50e87"
+component-image@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/component-image/-/component-image-2.0.0.tgz#33d10210c472c30d1b6c97fcdae241f34d2806c3"
   dependencies:
-    lodash.merge "^4.6.0"
-    nunjucks "^3.0.1"
-    puppeteer "^0.10.1"
-    react "^15.6.1"
-    react-dom "^15.6.1"
+    lodash.merge "^4.6.1"
+    nunjucks "^3.1.2"
+    puppeteer "^1.1.0"
+    react "^16.2.0"
+    react-dom "^16.2.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3318,7 +3318,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.6.0, create-react-class@^15.6.2:
+create-react-class@^15.5.2, create-react-class@^15.6.2:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
@@ -6820,7 +6820,7 @@ lodash.merge@^3.3.2:
     lodash.keysin "^3.0.0"
     lodash.toplainobject "^3.0.0"
 
-lodash.merge@^4.6.0:
+lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
@@ -7494,7 +7494,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nunjucks@^3.0.1:
+nunjucks@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.1.2.tgz#85945a66bb8239bb37ecef83dab4cc1f152aabb9"
   dependencies:
@@ -8446,9 +8446,9 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-puppeteer@^0.10.1:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.10.2.tgz#b4a959a722bf626ca481f2aeba11fdb810f2c98f"
+puppeteer@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.1.1.tgz#adbf25e49f5ef03443c10ab8e09a954ca0c7bfee"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"
@@ -8601,15 +8601,6 @@ react-docgen@^3.0.0-beta11:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
 react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
@@ -8747,16 +8738,6 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
-
-react@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 react@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
fixes #123 

When the breadcrumb was being passed in as null/empty array it was showing a "ghost" breadcrumb
*before:*
![screen shot 2018-03-12 at 11 01 04](https://user-images.githubusercontent.com/1695055/37280090-b0effaac-25e4-11e8-8e3a-920d3b5578bb.png)

*after:*
![screen shot 2018-03-12 at 10 59 02](https://user-images.githubusercontent.com/1695055/37280114-c1012510-25e4-11e8-972d-11f0711afdaf.png)

