### PR TITLE
Allow recomposition/restyling of existing components

### DIFF
--- a/components/back-link/src/__snapshots__/test.js.snap
+++ b/components/back-link/src/__snapshots__/test.js.snap
@@ -49,6 +49,11 @@ exports[`Back Link matches wrapper snapshot: wrapper mount 1`] = `
   goBack={[Function]}
 >
   <glamorous(button)
+    css={
+      Array [
+        undefined,
+      ]
+    }
     onClick={[Function]}
   >
     <button

--- a/components/back-link/src/index.js
+++ b/components/back-link/src/index.js
@@ -45,8 +45,8 @@ const Anchor = glamorous.button({
   },
 });
 
-const BackLink = ({ children, goBack }) => (
-  <Anchor onClick={goBack}>{children}</Anchor>
+const BackLink = ({ children, goBack, className }) => (
+  <Anchor onClick={goBack} css={[className]}>{children}</Anchor>
 );
 
 BackLink.propTypes = {
@@ -58,10 +58,15 @@ BackLink.propTypes = {
    * A function that is called on click
    */
   goBack: PropTypes.func, // TODO: rename onClick
+  /**
+   * A component using this component can override the styling of this component (recomposed styles)
+   */
+  className: PropTypes.string,
 };
 
 BackLink.defaultProps = {
   goBack: undefined,
+  className: undefined,
 };
 
 export default BackLink;

--- a/components/breadcrumb/src/__snapshots__/test.js.snap
+++ b/components/breadcrumb/src/__snapshots__/test.js.snap
@@ -79,7 +79,13 @@ exports[`breadcrumb matches snapshot: enzyme.mount 1`] = `
 }
 
 <Breadcrumb>
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-3"
     >

--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -66,8 +66,8 @@ const BreadcrumbListItem = glamorous.li({
 });
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const Breadcrumb = ({ children }) => (
-  <BreadcrumbContainer>
+const Breadcrumb = ({ children, className }) => (
+  <BreadcrumbContainer css={[className]}>
     <BreadcrumbList>
       {children.length && children.map ? (
         children.map((child, i) => (
@@ -87,6 +87,11 @@ Breadcrumb.propTypes = {
    * Generally a series of anchors or Link components
    */
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+Breadcrumb.defaultProps = {
+  className: undefined,
 };
 
 export default Breadcrumb;

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -28,7 +28,13 @@ exports[`button matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <Button>
-  <glamorous(button)>
+  <glamorous(button)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <button
       className="glamor-0"
     >

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -6,6 +6,7 @@
 // https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_buttons.scss
 
 import glamorous from 'glamorous';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {
@@ -57,10 +58,15 @@ const GButton = glamorous.button(
 );
 
 // TODO: start and iconUrl props
-const Button = props => <GButton {...props} />;
+const Button = props => <GButton {...props} css={[props.className]} />;
 
 Button.defaultProps = {
-  children: 'Button',
+  className: undefined,
+};
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default Button;

--- a/components/checkbox/src/__snapshots__/test.js.snap
+++ b/components/checkbox/src/__snapshots__/test.js.snap
@@ -80,7 +80,13 @@ exports[`Checkbox matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <Checkbox>
-  <glamorous(label)>
+  <glamorous(label)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <label
       className="glamor-2"
     >

--- a/components/checkbox/src/index.js
+++ b/components/checkbox/src/index.js
@@ -80,8 +80,13 @@ const Label = glamorous.span({
   },
 });
 
-const Checkbox = ({ children, inline, ...input }) => (
-  <CheckboxWrapper inline={inline}>
+const Checkbox = ({
+  children,
+  inline,
+  className,
+  ...input
+}) => (
+  <CheckboxWrapper css={[className]} inline={inline}>
     <Input type="checkbox" {...input} />
     <Label>{children}</Label>
   </CheckboxWrapper>
@@ -89,11 +94,13 @@ const Checkbox = ({ children, inline, ...input }) => (
 
 Checkbox.defaultProps = {
   inline: undefined,
+  className: undefined,
 };
 
 Checkbox.propTypes = {
   children: PropTypes.node.isRequired,
   inline: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default Checkbox;

--- a/components/date-input/src/__snapshots__/test.js.snap
+++ b/components/date-input/src/__snapshots__/test.js.snap
@@ -144,9 +144,13 @@ exports[`DateInput matches wrappersnapshot: wrapper mount 1`] = `
 
 <DateInput
   errorText="example"
-  hintText={null}
 >
   <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
     errorText="example"
   >
     <div

--- a/components/date-input/src/index.js
+++ b/components/date-input/src/index.js
@@ -71,41 +71,45 @@ const ListParent = glamorous.div({
   },
 });
 
-const DateInput = ({ children, ...props }) => (
-  <LabelWrapper errorText={props.errorText}>
-    <LabelText errorText={props.errorText}>{children}</LabelText>
-    {props.hintText ? <HintText>{props.hintText}</HintText> : <span />}
-    {props.errorText ? (
-      <ErrorText errorText={props.errorText}>{props.errorText}</ErrorText>
+const DateInput = ({
+  children, errorText, hintText, className,
+}) => (
+  <LabelWrapper errorText={errorText} css={[className]}>
+    <LabelText errorText={errorText}>{children}</LabelText>
+    {hintText ? <HintText>{hintText}</HintText> : <span />}
+    {errorText ? (
+      <ErrorText errorText={errorText}>{errorText}</ErrorText>
     ) : (
       <span />
     )}
     <ListParent>
       <Label>
         <LabelText>Day</LabelText>
-        <Input errorText={props.errorText} type="text" />
+        <Input errorText={errorText} type="text" />
       </Label>
       <Label>
         <LabelText>Month</LabelText>
-        <Input errorText={props.errorText} type="text" />
+        <Input errorText={errorText} type="text" />
       </Label>
       <Label className="year">
         <LabelText>Year</LabelText>
-        <Input errorText={props.errorText} type="text" />
+        <Input errorText={errorText} type="text" />
       </Label>
     </ListParent>
   </LabelWrapper>
 );
 
 DateInput.defaultProps = {
-  hintText: null,
-  errorText: null,
+  hintText: undefined,
+  errorText: undefined,
+  className: undefined,
 };
 
 DateInput.propTypes = {
   children: PropTypes.node.isRequired,
   hintText: PropTypes.string,
   errorText: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default DateInput;

--- a/components/file-upload/src/__snapshots__/test.js.snap
+++ b/components/file-upload/src/__snapshots__/test.js.snap
@@ -73,12 +73,22 @@ exports[`FileUpload matches snapshot: enzyme.mount 1`] = `
 }
 
 <FileUpload
-  acceptedFormats={null}
-  hint={null}
   meta={Object {}}
 >
-  <Label>
-    <glamorous(label)>
+  <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
+    <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
+    >
       <label
         className="glamor-2"
       >
@@ -92,11 +102,9 @@ exports[`FileUpload matches snapshot: enzyme.mount 1`] = `
           </glamorous(span)>
         </LabelText>
         <glamorous(input)
-          accept={null}
           type="file"
         >
           <input
-            accept={null}
             className="glamor-1"
             type="file"
           />

--- a/components/file-upload/src/index.js
+++ b/components/file-upload/src/index.js
@@ -30,9 +30,9 @@ const Input = glamorous.input({
 });
 
 const FileUpload = ({
-  meta, children, hint, acceptedFormats,
+  meta, children, hint, acceptedFormats, className,
 }) => (
-  <Label error={meta.error}>
+  <Label error={meta.error} css={[className]}>
     <LabelText error={meta.error}>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -41,9 +41,10 @@ const FileUpload = ({
 );
 
 FileUpload.defaultProps = {
-  hint: null,
+  hint: undefined,
   meta: {},
-  acceptedFormats: null,
+  acceptedFormats: undefined,
+  className: undefined,
 };
 
 FileUpload.propTypes = {
@@ -65,6 +66,7 @@ FileUpload.propTypes = {
   }),
   children: PropTypes.node.isRequired,
   acceptedFormats: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default FileUpload;

--- a/components/grid-row/src/index.js
+++ b/components/grid-row/src/index.js
@@ -17,10 +17,17 @@ const GridRowInner = glamorous.div({
   },
 });
 
-const GridRow = ({ children }) => <GridRowInner>{children}</GridRowInner>;
+const GridRow = ({ children, className }) => (
+  <GridRowInner css={[className]}>{children}</GridRowInner>
+);
+
+GridRow.defaultProps = {
+  className: undefined,
+};
 
 GridRow.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default GridRow;

--- a/components/input-field/src/__snapshots__/test.js.snap
+++ b/components/input-field/src/__snapshots__/test.js.snap
@@ -83,12 +83,23 @@ exports[`InputField matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <InputField
-  hint={null}
   input={Object {}}
   meta={Object {}}
 >
-  <Label>
-    <glamorous(label)>
+  <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
+    <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
+    >
       <label
         className="glamor-2"
       >

--- a/components/input-field/src/index.js
+++ b/components/input-field/src/index.js
@@ -11,9 +11,9 @@ import HintText from '@govuk-react/hint-text';
 import Input from '@govuk-react/input';
 
 const InputField = ({
-  meta, children, hint, input,
+  meta, children, hint, input, className,
 }) => (
-  <Label error={meta.touched && meta.error}>
+  <Label error={meta.touched && meta.error} css={[className]}>
     <LabelText>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -22,13 +22,15 @@ const InputField = ({
 );
 
 InputField.defaultProps = {
-  hint: null,
+  hint: undefined,
+  className: undefined,
   input: {},
   meta: {},
 };
 
 InputField.propTypes = {
   hint: PropTypes.string,
+  className: PropTypes.string,
   input: PropTypes.shape({
     name: PropTypes.string,
     onBlur: PropTypes.func,

--- a/components/layout/src/__snapshots__/test.js.snap
+++ b/components/layout/src/__snapshots__/test.js.snap
@@ -27,7 +27,13 @@ exports[`Layout matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <Layout>
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-0"
     >

--- a/components/layout/src/index.js
+++ b/components/layout/src/index.js
@@ -17,10 +17,15 @@ const LayoutInner = glamorous.div({
   },
 });
 
-const Layout = ({ children }) => <LayoutInner>{children}</LayoutInner>;
+const Layout = ({ children, className }) => <LayoutInner css={[className]}>{children}</LayoutInner>;
+
+Layout.defaultProps = {
+  className: undefined,
+};
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default Layout;

--- a/components/list-item/src/index.js
+++ b/components/list-item/src/index.js
@@ -23,10 +23,15 @@ const GListItem = glamorous.li({
   },
 });
 
-const ListItem = ({ children }) => <GListItem>{children}</GListItem>;
+const ListItem = ({ children, className }) => <GListItem css={[className]}>{children}</GListItem>;
+
+ListItem.defaultProps = {
+  className: undefined,
+};
 
 ListItem.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default ListItem;

--- a/components/list-navigation/src/__snapshots__/test.js.snap
+++ b/components/list-navigation/src/__snapshots__/test.js.snap
@@ -49,13 +49,24 @@ exports[`ListNavigation matches wrapper snapshot: wrapper mount 1`] = `
     listStyleType="square"
   >
     <glamorous(ul)
+      css={
+        Array [
+          undefined,
+        ]
+      }
       listStyleType="square"
     >
       <ul
         className="glamor-1"
       >
         <ListItem>
-          <glamorous(li)>
+          <glamorous(li)
+            css={
+              Array [
+                undefined,
+              ]
+            }
+          >
             <li
               className="glamor-0"
             >

--- a/components/list-navigation/src/index.js
+++ b/components/list-navigation/src/index.js
@@ -7,8 +7,8 @@ import UnorderedList from '@govuk-react/unordered-list';
 import ListItem from '@govuk-react/list-item';
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const ListNavigation = ({ children, listStyleType }) => (
-  <UnorderedList listStyleType={listStyleType}>
+const ListNavigation = ({ children, listStyleType, className }) => (
+  <UnorderedList listStyleType={listStyleType} className={className}>
     {children.length && children.map ? (
       children.map((child, i) => (
         <ListItem key={child.key || i}>{child}</ListItem>
@@ -21,11 +21,13 @@ const ListNavigation = ({ children, listStyleType }) => (
 
 ListNavigation.defaultProps = {
   listStyleType: undefined,
+  className: undefined,
 };
 
 ListNavigation.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default ListNavigation;

--- a/components/multi-choice/src/__snapshots__/test.js.snap
+++ b/components/multi-choice/src/__snapshots__/test.js.snap
@@ -51,7 +51,13 @@ exports[`MultiChoice matches withError snapshot: with error mount 1`] = `
   label="example"
   meta={Object {}}
 >
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-1"
     >
@@ -174,6 +180,11 @@ exports[`MultiChoice matches wrapper snapshot: wrapper mount 1`] = `
   }
 >
   <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
     error="example"
   >
     <div

--- a/components/multi-choice/src/index.js
+++ b/components/multi-choice/src/index.js
@@ -52,9 +52,9 @@ const FieldSet = glamorous.div(
 );
 
 const MultiChoice = ({
-  meta, label, children, hint,
+  meta, label, children, hint, className,
 }) => (
-  <FieldSet error={meta.touched && meta.error}>
+  <FieldSet error={meta.touched && meta.error} css={[className]}>
     <LabelText>{label}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -64,6 +64,7 @@ const MultiChoice = ({
 
 MultiChoice.defaultProps = {
   hint: undefined,
+  className: undefined,
   meta: {},
 };
 
@@ -86,6 +87,7 @@ MultiChoice.propTypes = {
   label: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
   hint: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default MultiChoice;

--- a/components/ordered-list/src/__snapshots__/test.js.snap
+++ b/components/ordered-list/src/__snapshots__/test.js.snap
@@ -63,12 +63,24 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <OrderedList>
-  <glamorous(ol)>
+  <glamorous(ol)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <ol
       className="glamor-9"
     >
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >
@@ -91,7 +103,13 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
         </glamorous(li)>
       </ListItem>
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >
@@ -114,7 +132,13 @@ exports[`OrderedList matches wrapper snapshot: wrapper mount 1`] = `
         </glamorous(li)>
       </ListItem>
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >

--- a/components/ordered-list/src/index.js
+++ b/components/ordered-list/src/index.js
@@ -34,17 +34,19 @@ const GOrderedListInner = glamorous.ol(
 );
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const OrderedList = ({ children, listStyleType }) => (
-  <GOrderedListInner listStyleType={listStyleType}>{children}</GOrderedListInner>
+const OrderedList = ({ children, listStyleType, className }) => (
+  <GOrderedListInner listStyleType={listStyleType} css={[className]}>{children}</GOrderedListInner>
 );
 
 OrderedList.defaultProps = {
   listStyleType: undefined,
+  className: undefined,
 };
 
 OrderedList.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default OrderedList;

--- a/components/pagination/src/index.js
+++ b/components/pagination/src/index.js
@@ -30,12 +30,17 @@ const PaginationWrapper = glamorous.ul({
   },
 });
 
-const Pagination = ({ children }) => (
-  <PaginationWrapper>{children}</PaginationWrapper>
+const Pagination = ({ children, className }) => (
+  <PaginationWrapper css={[className]}>{children}</PaginationWrapper>
 );
+
+Pagination.defaultProps = {
+  className: undefined,
+};
 
 Pagination.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default Pagination;

--- a/components/panel/src/__snapshots__/test.js.snap
+++ b/components/panel/src/__snapshots__/test.js.snap
@@ -51,7 +51,13 @@ exports[`Panel matches wrapper snapshot: wrapper mount 1`] = `
   panelBody="body"
   panelTitle="Example"
 >
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-2"
     >

--- a/components/panel/src/index.js
+++ b/components/panel/src/index.js
@@ -41,19 +41,21 @@ const PanelBody = glamorous.div({
   },
 });
 
-const Panel = ({ panelTitle, panelBody }) => (
-  <PanelInner>
+const Panel = ({ panelTitle, panelBody, className }) => (
+  <PanelInner css={[className]}>
     <PanelTitle>{panelTitle}</PanelTitle>
     <PanelBody>{panelBody}</PanelBody>
   </PanelInner>
 );
 Panel.defaultProps = {
-  panelBody: null,
+  panelBody: undefined,
+  className: undefined,
 };
 
 Panel.propTypes = {
   panelTitle: PropTypes.string.isRequired,
   panelBody: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default Panel;

--- a/components/phase-banner/src/__snapshots__/test.js.snap
+++ b/components/phase-banner/src/__snapshots__/test.js.snap
@@ -57,7 +57,13 @@ exports[`PhaseBanner matches wrapper snapshot: wrapper mount 1`] = `
 <PhaseBanner
   level="beta"
 >
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-1"
     >

--- a/components/phase-banner/src/index.js
+++ b/components/phase-banner/src/index.js
@@ -32,16 +32,21 @@ const PhaseBannerInner = glamorous.div({
   },
 });
 
-const PhaseBanner = ({ level, children }) => (
-  <PhaseBannerInner>
+const PhaseBanner = ({ level, children, className }) => (
+  <PhaseBannerInner css={[className]}>
     <PhaseBadge>{level}</PhaseBadge>
     {children}
   </PhaseBannerInner>
 );
 
+PhaseBanner.defaultProps = {
+  className: undefined,
+};
+
 PhaseBanner.propTypes = {
   children: PropTypes.node.isRequired,
   level: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
 
 export default PhaseBanner;

--- a/components/radio/src/__snapshots__/test.js.snap
+++ b/components/radio/src/__snapshots__/test.js.snap
@@ -85,6 +85,11 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   name="example"
 >
   <glamorous(label)
+    css={
+      Array [
+        undefined,
+      ]
+    }
     inline={true}
   >
     <label
@@ -195,7 +200,13 @@ exports[`Radio matches snapshot: standard mount 1`] = `
 <Radio
   name="example"
 >
-  <glamorous(label)>
+  <glamorous(label)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <label
       className="glamor-2"
     >

--- a/components/radio/src/index.js
+++ b/components/radio/src/index.js
@@ -88,8 +88,13 @@ const LabelText = glamorous.span({
   },
 });
 
-const Radio = ({ inline, children, ...input }) => (
-  <Label inline={inline}>
+const Radio = ({
+  inline,
+  children,
+  className,
+  ...input
+}) => (
+  <Label inline={inline} css={[className]}>
     <Input type="radio" {...input} />
     <LabelText>{children}</LabelText>
   </Label>
@@ -97,11 +102,13 @@ const Radio = ({ inline, children, ...input }) => (
 
 Radio.defaultProps = {
   inline: undefined,
+  className: undefined,
 };
 
 Radio.propTypes = {
   inline: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };
 
 export default Radio;

--- a/components/search-box/src/__snapshots__/test.js.snap
+++ b/components/search-box/src/__snapshots__/test.js.snap
@@ -69,7 +69,13 @@ exports[`SearchBox matches wrapper snapshot: wrapper mount 1`] = `
 <SearchBox
   placeholder="example"
 >
-  <glamorous(div)>
+  <glamorous(div)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <div
       className="glamor-2"
     >

--- a/components/search-box/src/index.js
+++ b/components/search-box/src/index.js
@@ -60,8 +60,8 @@ const SearchButton = glamorous.button({
   },
 });
 
-const SearchBox = ({ placeholder }) => (
-  <SearchBoxWrapper>
+const SearchBox = ({ placeholder, className }) => (
+  <SearchBoxWrapper css={[className]}>
     <InputSearchBox type="search" placeholder={placeholder} />
     <SearchButton title="Search">
       <Search colour="#fff" />
@@ -71,10 +71,12 @@ const SearchBox = ({ placeholder }) => (
 
 SearchBox.defaultProps = {
   placeholder: undefined,
+  className: undefined,
 };
 
 SearchBox.propTypes = {
   placeholder: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default SearchBox;

--- a/components/select/src/__snapshots__/test.js.snap
+++ b/components/select/src/__snapshots__/test.js.snap
@@ -142,9 +142,19 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
   }
 >
   <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
     error="example"
   >
     <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
       error="example"
     >
       <label
@@ -275,13 +285,24 @@ exports[`Select matches snapshot: enzyme.mount 1`] = `
 }
 
 <Select
-  errorText={null}
   input={Object {}}
   label="example"
   meta={Object {}}
 >
-  <Label>
-    <glamorous(label)>
+  <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
+    <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
+    >
       <label
         className="glamor-2"
       >

--- a/components/select/src/index.js
+++ b/components/select/src/index.js
@@ -44,9 +44,9 @@ const Input = glamorous.select(
 );
 
 const Select = ({
-  children, hint, label, meta, input,
+  children, hint, label, meta, input, className,
 }) => (
-  <Label error={meta.touched && meta.error}>
+  <Label error={meta.touched && meta.error} css={[className]}>
     <LabelText>{label}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -58,9 +58,10 @@ const Select = ({
 
 Select.defaultProps = {
   hint: undefined,
-  errorText: null,
   input: {},
   meta: {},
+  errorText: undefined,
+  className: undefined,
 };
 
 Select.propTypes = {
@@ -90,6 +91,7 @@ Select.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
   errorText: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default Select;

--- a/components/text-area/src/__snapshots__/test.js.snap
+++ b/components/text-area/src/__snapshots__/test.js.snap
@@ -106,7 +106,6 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
 
 <TextArea
   errorText="example"
-  hint={null}
   input={Object {}}
   meta={
     Object {
@@ -116,9 +115,19 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   }
 >
   <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
     error="example"
   >
     <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
       error="example"
     >
       <label
@@ -262,8 +271,20 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
   input={Object {}}
   meta={Object {}}
 >
-  <Label>
-    <glamorous(label)>
+  <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
+    <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
+    >
       <label
         className="glamor-3"
       >
@@ -379,12 +400,23 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <TextArea
-  hint={null}
   input={Object {}}
   meta={Object {}}
 >
-  <Label>
-    <glamorous(label)>
+  <Label
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
+    <glamorous(label)
+      css={
+        Array [
+          undefined,
+        ]
+      }
+    >
       <label
         className="glamor-2"
       >

--- a/components/text-area/src/index.js
+++ b/components/text-area/src/index.js
@@ -39,29 +39,37 @@ const TextareaField = glamorous.textarea(
   }),
 );
 
-const TextArea = props => (
-  <Label error={props.meta.touched && props.meta.error}>
-    <LabelText>{props.children}</LabelText>
-    {props.hint && <HintText>{props.hint}</HintText>}
-    {props.meta.touched &&
-      props.meta.error && <ErrorText>{props.meta.error}</ErrorText>}
+const TextArea = ({
+  meta,
+  children,
+  hint,
+  className,
+  input,
+}) => (
+  <Label error={meta.touched && meta.error} css={[className]}>
+    <LabelText>{children}</LabelText>
+    {hint && <HintText>{hint}</HintText>}
+    {meta.touched &&
+      meta.error && <ErrorText>{meta.error}</ErrorText>}
     <TextareaField
       type="text"
       rows="5"
-      error={props.meta.touched && props.meta.error}
-      {...props.input}
+      error={meta.touched && meta.error}
+      {...input}
     />
   </Label>
 );
 
 TextArea.defaultProps = {
-  hint: null,
+  hint: undefined,
+  className: undefined,
   input: {},
   meta: {},
 };
 
 TextArea.propTypes = {
   hint: PropTypes.string,
+  className: PropTypes.string,
   input: PropTypes.shape({
     name: PropTypes.string,
     onBlur: PropTypes.func,

--- a/components/unordered-list/src/__snapshots__/test.js.snap
+++ b/components/unordered-list/src/__snapshots__/test.js.snap
@@ -63,12 +63,24 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 <UnorderedList>
-  <glamorous(ul)>
+  <glamorous(ul)
+    css={
+      Array [
+        undefined,
+      ]
+    }
+  >
     <ul
       className="glamor-9"
     >
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >
@@ -91,7 +103,13 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
         </glamorous(li)>
       </ListItem>
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >
@@ -114,7 +132,13 @@ exports[`UnorderedList matches wrapper snapshot: wrapper mount 1`] = `
         </glamorous(li)>
       </ListItem>
       <ListItem>
-        <glamorous(li)>
+        <glamorous(li)
+          css={
+            Array [
+              undefined,
+            ]
+          }
+        >
           <li
             className="glamor-2"
           >

--- a/components/unordered-list/src/index.js
+++ b/components/unordered-list/src/index.js
@@ -37,17 +37,19 @@ const GUnorderedList = glamorous.ul(
 
 // listStyleType: normal HTML property values are used here
 // e.g., listStyleType="circle", listStyleType="upper-alpha", listStyleType="none"
-const UnorderedList = ({ children, listStyleType }) => (
-  <GUnorderedList listStyleType={listStyleType}>{children}</GUnorderedList>
+const UnorderedList = ({ children, listStyleType, className }) => (
+  <GUnorderedList listStyleType={listStyleType} css={[className]}>{children}</GUnorderedList>
 );
 
 UnorderedList.defaultProps = {
   listStyleType: undefined,
+  className: undefined,
 };
 
 UnorderedList.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default UnorderedList;

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -27,12 +27,15 @@ export { default as SearchBox } from '@govuk-react/search-box';
 export { default as Select } from '@govuk-react/select';
 export { default as TextArea } from '@govuk-react/text-area';
 export { default as UnorderedList } from '@govuk-react/unordered-list';
+// export { default as RelatedItems } from '@govuk-react/related-items';
 
 export { H1, H2, H3, H4, H5, H6 } from '@govuk-react/header';
 
 // Higher Order Components
-export { asAnchor } from '@govuk-react/hoc';
-export { asPaginationItem } from '@govuk-react/hoc';
+export {
+  asAnchor,
+  asPaginationItem,
+} from '@govuk-react/hoc';
 
 // Icons
 export { Search as SearchIcon } from '@govuk-react/icons';

--- a/packages/hoc/src/asComponent/__snapshots__/test.js.snap
+++ b/packages/hoc/src/asComponent/__snapshots__/test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`asComponent matches wrapper snapshot: wrapper mount 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  border: 2px dashed red;
+}
+
+<RecomposedComponent
+  className="glamor-0"
+  href="https://example.com"
+>
+  Example
+</RecomposedComponent>
+`;

--- a/packages/hoc/src/asComponent/__snapshots__/test.js.snap
+++ b/packages/hoc/src/asComponent/__snapshots__/test.js.snap
@@ -8,7 +8,6 @@ exports[`asComponent matches wrapper snapshot: wrapper mount 1`] = `
 
 <RecomposedComponent
   className="glamor-0"
-  href="https://example.com"
 >
   Example
 </RecomposedComponent>

--- a/packages/hoc/src/asComponent/index.js
+++ b/packages/hoc/src/asComponent/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import glamorous from 'glamorous';
+
+const asComponent = (Component) => {
+  const RecomposedComponent = props => (
+    <Component {...props} css={[props.className]}>{props.children}</Component>
+  );
+
+  RecomposedComponent.propTypes = {
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+      .isRequired,
+    onClick: PropTypes.func,
+    disabled: PropTypes.bool,
+    className: PropTypes.string,
+  };
+
+  RecomposedComponent.defaultProps = {
+    onClick: undefined,
+    disabled: undefined,
+    className: undefined,
+  };
+
+  const StyledHoc = glamorous(RecomposedComponent)({
+    border: '2px dashed red',
+  });
+
+  return StyledHoc;
+};
+
+export default asComponent;

--- a/packages/hoc/src/asComponent/stories.js
+++ b/packages/hoc/src/asComponent/stories.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import BackLink from '@govuk-react/back-link';
+import Breadcrumb from '@govuk-react/breadcrumb';
+import Button from '@govuk-react/button';
+import Checkbox from '@govuk-react/checkbox';
+import DateInput from '@govuk-react/date-input';
+// import DocumentFooterMetadata from '@govuk-react/document-footer-metadata';
+import ErrorText from '@govuk-react/error-text';
+import FileUpload from '@govuk-react/file-upload';
+import GridCol from '@govuk-react/grid-col';
+import GridRow from '@govuk-react/grid-row';
+import Header from '@govuk-react/header';
+import HintText from '@govuk-react/hint-text';
+import Input from '@govuk-react/input';
+import InputField from '@govuk-react/input-field';
+import Label from '@govuk-react/label';
+import LabelText from '@govuk-react/label-text';
+import Layout from '@govuk-react/layout';
+import ListItem from '@govuk-react/list-item';
+import ListNavigation from '@govuk-react/list-navigation';
+import MultiChoice from '@govuk-react/multi-choice';
+import OrderedList from '@govuk-react/ordered-list';
+import Pagination from '@govuk-react/pagination';
+import Panel from '@govuk-react/panel';
+import PhaseBadge from '@govuk-react/phase-badge';
+import PhaseBanner from '@govuk-react/phase-banner';
+import Radio from '@govuk-react/radio';
+// import RelatedItems from '@govuk-react/related-items';
+import SearchBox from '@govuk-react/search-box';
+import Select from '@govuk-react/select';
+import TextArea from '@govuk-react/text-area';
+import UnorderedList from '@govuk-react/unordered-list';
+
+import asComponent from '.';
+
+const RCBackLink = asComponent(BackLink);
+const RCBreadcrumb = asComponent(Breadcrumb);
+const RCButton = asComponent(Button);
+const RCCheckbox = asComponent(Checkbox);
+const RCDateInput = asComponent(DateInput);
+const RCErrorText = asComponent(ErrorText);
+const RCFileUpload = asComponent(FileUpload);
+const RCGridCol = asComponent(GridCol);
+const RCGridRow = asComponent(GridRow);
+const RCHeader = asComponent(Header);
+const RCHintText = asComponent(HintText);
+const RCInput = asComponent(Input);
+const RCInputField = asComponent(InputField);
+const RCLabel = asComponent(Label);
+const RCLabelText = asComponent(LabelText);
+const RCLayout = asComponent(Layout);
+const RCListItem = asComponent(ListItem);
+const RCListNavigation = asComponent(ListNavigation);
+const RCMultiChoice = asComponent(MultiChoice);
+const RCOrderedList = asComponent(OrderedList);
+const RCPagination = asComponent(Pagination);
+const RCPanel = asComponent(Panel);
+const RCPhaseBadge = asComponent(PhaseBadge);
+const RCPhaseBanner = asComponent(PhaseBanner);
+const RCRadio = asComponent(Radio);
+// const RCRelatedItems = asComponent(RelatedItems);
+const RCSearchBox = asComponent(SearchBox);
+const RCSelect = asComponent(Select);
+const RCTextArea = asComponent(TextArea);
+const RCUnorderedList = asComponent(UnorderedList);
+
+storiesOf('asComponent', module).add('BackLink', () => (
+  <RCBackLink>example</RCBackLink>
+));
+
+storiesOf('asComponent', module).add('Breadcrumb', () => (
+  <RCBreadcrumb>example</RCBreadcrumb>
+));
+
+storiesOf('asComponent', module).add('Button', () => (
+  <RCButton>example</RCButton>
+));
+
+storiesOf('asComponent', module).add('RCCheckbox', () => (
+  <RCCheckbox>example</RCCheckbox>
+));
+
+storiesOf('asComponent', module).add('RCDateInput', () => (
+  <RCDateInput>example</RCDateInput>
+));
+
+storiesOf('asComponent', module).add('RCErrorText', () => (
+  <RCErrorText>example</RCErrorText>
+));
+
+storiesOf('asComponent', module).add('RCFileUpload', () => (
+  <RCFileUpload>example</RCFileUpload>
+));
+
+storiesOf('asComponent', module).add('RCGridCol', () => (
+  <RCGridCol>example</RCGridCol>
+));
+
+storiesOf('asComponent', module).add('RCGridRow', () => (
+  <RCGridRow>example</RCGridRow>
+));
+
+storiesOf('asComponent', module).add('RCHeader', () => (
+  <RCHeader>example</RCHeader>
+));
+
+storiesOf('asComponent', module).add('RCHintText', () => (
+  <RCHintText>example</RCHintText>
+));
+
+storiesOf('asComponent', module).add('RCInput', () => (
+  <RCInput />
+));
+
+storiesOf('asComponent', module).add('RCInputField', () => (
+  <RCInputField>example</RCInputField>
+));
+
+storiesOf('asComponent', module).add('RCLabel', () => (
+  <RCLabel>example</RCLabel>
+));
+
+storiesOf('asComponent', module).add('RCLabelText', () => (
+  <RCLabelText>example</RCLabelText>
+));
+
+storiesOf('asComponent', module).add('RCLayout', () => (
+  <RCLayout>example</RCLayout>
+));
+
+storiesOf('asComponent', module).add('RCListItem', () => (
+  <RCListItem>example</RCListItem>
+));
+
+storiesOf('asComponent', module).add('RCListNavigation', () => (
+  <RCListNavigation>example</RCListNavigation>
+));
+
+storiesOf('asComponent', module).add('RCMultiChoice', () => (
+  <RCMultiChoice>example</RCMultiChoice>
+));
+
+storiesOf('asComponent', module).add('RCOrderedList', () => (
+  <RCOrderedList>example</RCOrderedList>
+));
+
+storiesOf('asComponent', module).add('RCPagination', () => (
+  <RCPagination>example</RCPagination>
+));
+
+storiesOf('asComponent', module).add('RCPanel', () => (
+  <RCPanel>example</RCPanel>
+));
+
+storiesOf('asComponent', module).add('RCPhaseBadge', () => (
+  <RCPhaseBadge>example</RCPhaseBadge>
+));
+
+storiesOf('asComponent', module).add('RCPhaseBanner', () => (
+  <RCPhaseBanner>example</RCPhaseBanner>
+));
+
+storiesOf('asComponent', module).add('RCRadio', () => (
+  <RCRadio>example</RCRadio>
+));
+
+// storiesOf('asComponent', module).add('RCRelatedItems', () => (
+//   <RCRelatedItems>example</RCRelatedItems>
+// ));
+
+storiesOf('asComponent', module).add('RCSearchBox', () => (
+  <RCSearchBox>example</RCSearchBox>
+));
+
+storiesOf('asComponent', module).add('RCSelect', () => (
+  <RCSelect>example</RCSelect>
+));
+
+storiesOf('asComponent', module).add('RCTextArea', () => (
+  <RCTextArea>example</RCTextArea>
+));
+
+storiesOf('asComponent', module).add('RCUnorderedList', () => (
+  <RCUnorderedList>example</RCUnorderedList>
+));

--- a/packages/hoc/src/asComponent/test.js
+++ b/packages/hoc/src/asComponent/test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+import asAnchor from './';
+
+const AnchorTag = asAnchor('a');
+
+const wrapper = <AnchorTag href="https://example.com">Example</AnchorTag>;
+
+describe(asAnchor, () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(wrapper, div);
+  });
+
+  it('returns a component', () => {
+    expect(shallow(wrapper).html().toBeTruthy);
+  });
+
+  it('matches wrapper snapshot', () => {
+    expect(shallow(wrapper)).toMatchSnapshot('wrapper mount');
+  });
+});

--- a/packages/hoc/src/asComponent/test.js
+++ b/packages/hoc/src/asComponent/test.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
-import asAnchor from './';
+import BackLink from '@govuk-react/back-link';
 
-const AnchorTag = asAnchor('a');
+import asComponent from './';
 
-const wrapper = <AnchorTag href="https://example.com">Example</AnchorTag>;
+const RCBackLink = asComponent(BackLink);
 
-describe(asAnchor, () => {
+const wrapper = <RCBackLink>Example</RCBackLink>;
+
+describe(asComponent, () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(wrapper, div);

--- a/packages/storybook/src/stories/index.js
+++ b/packages/storybook/src/stories/index.js
@@ -27,6 +27,8 @@ import '@govuk-react/ordered-list/lib/stories';
 import '@govuk-react/unordered-list/lib/stories';
 import '@govuk-react/list-item/lib/stories';
 import '@govuk-react/list-navigation/lib/stories';
+// import '@govuk-react/related-items/lib/stories';
 
 import '@govuk-react/hoc/lib/asAnchor/stories';
 import '@govuk-react/hoc/lib/asPaginationItem/stories';
+import '@govuk-react/hoc/lib/asComponent/stories';


### PR DESCRIPTION
- Added css prop to components that allows pass-through of styles to be able to override styles of a component, should it need it
- Added an HoC to give an example of how to override the component, not intended for export
- Added a test for the HoC to make sure it does what it's supposed to
- Fixed a couple of issues
  + `null` where should have been `undefined`
  + textarea was consuming all props, instead of just input props

Usage of the change would be as follows:
```
import BackLink from '@govuk-react/back-link';
const NewBackLink  = glamorous(BackLink)({
  backgroundColor: "blue",
  color: "white",
});
```

See [glamorous website](https://glamorous.rocks/basics/) "Overriding component styles" section (however it doesn't clearly explain the method, so i [wrote one](https://medium.com/@marksy/re-styling-a-compose-glamorous-component-b6c6aa728a3b) based on [KCD's tweet to me](https://twitter.com/kentcdodds/status/973531839708127232))