### PR TITLE
remove version numbers from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "govuk-react",
-  "version": "0.1.19",
   "scripts": {
     "start": "cd packages/storybook && npm start",
     "build-storybook": "npm run bootstrap && npm run build && cd packages/storybook && npm run build-storybook && cp -r storybook-static ../..",
     "bootstrap": "lerna bootstrap",
-    "docs": "doc-component '../../../components/**/lib/index.js' './API.md'",
+    "docs": "./packages/api-docs/bin/doc-component.js '../../../components/**/lib/index.js' './API.md'",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint --fix ./src",
     "build": "lerna run build --parallel",
@@ -79,7 +78,6 @@
     "@babel/preset-flow": "^7.0.0-beta.40",
     "@babel/preset-react": "^7.0.0-beta.40",
     "@babel/preset-stage-1": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "0.1.19",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.0",

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.20",
   "dependencies": {
     "@babel/node": "^7.0.0-beta.40",
+    "@babel/runtime": "^7.0.0-beta.40",
     "chalk": "^2.3.1",
     "commander": "^2.15.0",
     "glob": "^7.1.2",
@@ -14,7 +15,6 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
     "@babel/core": "^7.0.0-beta.40",
-    "@babel/runtime": "^7.0.0-beta.40",
     "babel-core": "^7.0.0-bridge.0",
     "glamorous": "^4.12.0",
     "prop-types": "^15.6.1",


### PR DESCRIPTION
Remove version numbers from root package.json, so that outdated version references are not left behind after a `lerna publish`, see:

https://github.com/lerna/lerna/issues/1335