### PR TITLE
Missing dependencies in govuk-react

### DIFF
--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -14,6 +14,7 @@
     "@govuk-react/grid-row": "^0.1.23",
     "@govuk-react/header": "^0.1.23",
     "@govuk-react/hint-text": "^0.1.23",
+    "@govuk-react/hoc": "^0.1.23",
     "@govuk-react/icons": "^0.1.23",
     "@govuk-react/input": "^0.1.23",
     "@govuk-react/input-field": "^0.1.23",

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -1,3 +1,6 @@
+// TODO: eslint needs to be configured to pick up exports that aren't in package.json
+// see https://github.com/benmosher/eslint-plugin-import/issues/1049
+
 // Components
 export { default as BackLink } from '@govuk-react/back-link';
 export { default as Breadcrumb } from '@govuk-react/breadcrumb';


### PR DESCRIPTION
Ideally this should be automatically picked up but awaiting feedback on associated eslint plugin - https://github.com/benmosher/eslint-plugin-import/issues/1049
