### PR TITLE
Get all tags before running lerna publish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # requires https://hub.github.com
 git checkout -b release/next origin/master # make a new branch for next version from master
+git fetch --tags # lerna uses tags to determine what has changed, we need to make sure we have all tags locally
 lerna publish --skip-npm # update version numbers
 VERSION=$(node -e 'console.log(require("./lerna.json").version)') # get new version number
 git tag -d v$VERSION # delete local tag


### PR DESCRIPTION
lerna uses tags to determine what has changed, we need to make sure we have all tags locally

see https://github.com/lerna/lerna/issues/1345
