### PR TITLE
Allow attributes to be set on Breadcrumbs

### DIFF
--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -66,12 +66,12 @@ const BreadcrumbListItem = glamorous.li({
 });
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const Breadcrumb = ({ children }) => (
-  <BreadcrumbContainer>
+const Breadcrumb = ({ children, ...props }) => (
+  <BreadcrumbContainer {...props}>
     <BreadcrumbList>
       {children.length && children.map ? (
         children.map((child, i) => (
-          child.length || child.props
+          child && (child.length || child.props)
             ? <BreadcrumbListItem key={child.key || i}>{child}</BreadcrumbListItem>
             : null
         ))

--- a/components/breadcrumb/src/test.js
+++ b/components/breadcrumb/src/test.js
@@ -7,6 +7,7 @@ import Breadcrumb from './';
 describe('breadcrumb', () => {
   const example = 'example';
   const emptyNode = [];
+  const nullNode = null;
   const wrapper = <Breadcrumb>{example}</Breadcrumb>;
   const wrapperMultiple = (
     <Breadcrumb>
@@ -18,6 +19,7 @@ describe('breadcrumb', () => {
     <Breadcrumb>
       <a href="/section">Section 1</a>
       {emptyNode}
+      {nullNode}
       {example}
     </Breadcrumb>
   );
@@ -38,6 +40,13 @@ describe('breadcrumb', () => {
 
   it('should render an unordered list without ghost/duff children', () => {
     expect(mount(wrapperEmptyNode).find('ul li')).toHaveLength(2);
+  });
+
+  it('allows attributes to be set', () => {
+    const output = mount(<Breadcrumb id="test" className="test">Crumb</Breadcrumb>);
+
+    expect(output.hasClass('test')).toBe(true);
+    expect(output.is('#test')).toBe(true);
   });
 
   it('matches snapshot', () => {

--- a/components/related-items/package.json
+++ b/components/related-items/package.json
@@ -5,6 +5,7 @@
     "access": "public"
   },
   "version": "0.1.23",
+  "license": "MIT",
   "dependencies": {
     "@govuk-react/constants": "^0.1.21",
     "govuk-colours": "^1.0.3"


### PR DESCRIPTION
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
