### PR TITLE
enhance dropdown (878)

### DIFF
--- a/components/select/src/index.js
+++ b/components/select/src/index.js
@@ -93,3 +93,4 @@ Select.propTypes = {
 };
 
 export default Select;
+export { Input as SelectInput };

--- a/components/select/src/stories.js
+++ b/components/select/src/stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Select, { SelectInput } from '.';
 import LabelText from '@govuk-react/label-text';
+import Select, { SelectInput } from '.';
 
 const meta = {
   touched: true,

--- a/components/select/src/stories.js
+++ b/components/select/src/stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Select from '.';
+import Select, { SelectInput } from '.';
+import LabelText from '@govuk-react/label-text';
 
 const meta = {
   touched: true,
@@ -42,4 +43,16 @@ storiesOf('Select', module).add('Select with hintText & error', () => (
     <option value="1">GOV.UK elements option 2</option>
     <option value="2">GOV.UK elements option 3</option>
   </Select>
+));
+
+storiesOf('Select', module).add('Standalone input with inline label', () => (
+  <label>
+    <LabelText>Sort by:&nbsp;
+      <SelectInput>
+        <option value="0">People</option>
+        <option value="1">Animals</option>
+        <option value="2">Vegetables</option>
+      </SelectInput>
+    </LabelText>
+  </label>
 ));


### PR DESCRIPTION
- export select-input as its own module
- show example of using a select inline with a label

this is the existing design of the dropdown (excluding the red rect.) which shows a label inline to a select dropdown. The dropdown needs to be shown in the GDS styling
