### PR TITLE
remove snyk vulnerability

### DIFF
--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -34,7 +34,6 @@
     "@govuk-react/related-items": "^0.1.26",
     "@govuk-react/search-box": "^0.1.26",
     "@govuk-react/select": "^0.1.26",
-    "@govuk-react/storybook": "^0.1.26",
     "@govuk-react/text-area": "^0.1.26",
     "@govuk-react/unordered-list": "^0.1.26",
     "govuk-colours": "^1.0.3"

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -1,7 +1,5 @@
 // TODO: eslint needs to be configured to pick up exports that aren't in package.json
 // see https://github.com/benmosher/eslint-plugin-import/issues/1049
-// In the meantime we are including @govuk-react/storybook as a dependency,
-//  which will help ensure subdependencies are included.
 
 // Components
 export { default as BackLink } from '@govuk-react/back-link';


### PR DESCRIPTION
We don't want a parent project to raise a snyk vulnerability when importing govuk-react.

Though the issues are not relevant, the storybook isn't really a required dependency, so removing this workaround for now.
