### PR TITLE
Bugfix/175 remove api docs dep

### DIFF
--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/addons": "^3.3.14",
     "@storybook/react": "^3.3.14",

--- a/components/breadcrumb/package.json
+++ b/components/breadcrumb/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/images": "^0.1.20",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/addon-knobs": "^3.3.14",

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/date-input/package.json
+++ b/components/date-input/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/document-footer-metadata/package.json
+++ b/components/document-footer-metadata/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/addons": "^3.3.14",

--- a/components/error-text/package.json
+++ b/components/error-text/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/file-upload/package.json
+++ b/components/file-upload/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/grid-col/package.json
+++ b/components/grid-col/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/grid-row/package.json
+++ b/components/grid-row/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/hint-text/package.json
+++ b/components/hint-text/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/input-field/package.json
+++ b/components/input-field/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/label-text/package.json
+++ b/components/label-text/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/layout/package.json
+++ b/components/layout/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/grid-col": "^0.1.27",
     "@govuk-react/grid-row": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",

--- a/components/list-item/package.json
+++ b/components/list-item/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/list-navigation/package.json
+++ b/components/list-navigation/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/addons": "^3.3.14",

--- a/components/multi-choice/package.json
+++ b/components/multi-choice/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/radio": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",

--- a/components/ordered-list/package.json
+++ b/components/ordered-list/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@govuk-react/list-item": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/phase-badge/package.json
+++ b/components/phase-badge/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/multi-choice": "^0.1.27",
     "@govuk-react/storybook-components": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",

--- a/components/related-items/package.json
+++ b/components/related-items/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/header": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@govuk-react/list-item": "^0.1.27",

--- a/components/search-box/package.json
+++ b/components/search-box/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/grid-col": "^0.1.27",
     "@govuk-react/grid-row": "^0.1.27",
     "@govuk-react/layout": "^0.1.27",

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/text-area/package.json
+++ b/components/text-area/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",

--- a/components/unordered-list/package.json
+++ b/components/unordered-list/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
-    "@govuk-react/api-docs": "^0.1.27",
     "@govuk-react/hoc": "^0.1.27",
     "@govuk-react/list-item": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",

--- a/packages/hoc/package.json
+++ b/packages/hoc/package.json
@@ -41,7 +41,7 @@
     "@govuk-react/text-area": "^0.1.27",
     "@govuk-react/unordered-list": "^0.1.27",
     "@storybook/addon-actions": "^3.3.14",
-    "@storybook/addon-knobs": "^3.4.0",
+    "@storybook/addon-knobs": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "cross-env": "^5.1.4",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
-  remove api-docs as a devDependency of all components as it causes unnecessary republishing, see #175 (hopefully fixes)


Unrelated:

- storybook/addon-knobs should be v3.3, Correct @storybook/addon-knobs version to match other storybook deps, was a warning during yarn install