### PR TITLE
Feature/normalise file upload label

### DIFF
--- a/components/file-upload/src/index.js
+++ b/components/file-upload/src/index.js
@@ -40,7 +40,7 @@ const FileUpload = ({
   meta, children, hint, acceptedFormats, className,
 }) => (
   <Label className={className} error={meta.error}>
-    <LabelText error={meta.error}>{children}</LabelText>
+    <LabelText>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
     <GInput type="file" accept={acceptedFormats} error={meta.error} />

--- a/components/file-upload/src/index.js
+++ b/components/file-upload/src/index.js
@@ -15,7 +15,7 @@ import {
   MEDIA_QUERIES,
 } from '@govuk-react/constants';
 
-const Input = glamorous.input({
+const GInput = glamorous.input({
   boxSizing: 'border-box',
   fontFamily: NTA_LIGHT,
   WebkitFontSmoothing: 'antialiased',
@@ -43,7 +43,7 @@ const FileUpload = ({
     <LabelText error={meta.error}>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
-    <Input type="file" accept={acceptedFormats} error={meta.error} />
+    <GInput type="file" accept={acceptedFormats} error={meta.error} />
   </Label>
 );
 


### PR DESCRIPTION
Whilst browsing Storybook I noticed that the `FileUpload` component rendered bold label text when there was an error, unlike any of the other form fields.

This change resolves this by removing the `error` prop passed to the `LabelText` component in `FileUpload` bringing it inline with the other form components and stops the label from rendering bold when there is an error.

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged