### PR TITLE
Fix uses of toBeTruthy in tests

### DIFF
--- a/packages/hoc/src/asAnchor/test.js
+++ b/packages/hoc/src/asAnchor/test.js
@@ -14,7 +14,7 @@ describe(asAnchor, () => {
   });
 
   it('returns a component', () => {
-    expect(shallow(wrapper).html().toBeTruthy);
+    expect(shallow(wrapper).html()).toBeTruthy();
   });
 
   it('matches wrapper snapshot', () => {

--- a/packages/hoc/src/asPaginationItem/test.js
+++ b/packages/hoc/src/asPaginationItem/test.js
@@ -37,7 +37,7 @@ describe(asPaginationItem, () => {
   });
 
   it('returns a component', () => {
-    expect(shallow(wrapper).html().toBeTruthy);
+    expect(shallow(wrapper).html()).toBeTruthy();
   });
 
   it('matches wrapper snapshot', () => {

--- a/packages/hoc/src/withWhiteSpace/test.js
+++ b/packages/hoc/src/withWhiteSpace/test.js
@@ -22,7 +22,7 @@ describe(withWhiteSpace, () => {
   });
 
   it('returns a component', () => {
-    expect(shallow(wrapper).html().toBeTruthy);
+    expect(shallow(wrapper).html()).toBeTruthy();
   });
 
   it('matches wrapper snapshot', () => {


### PR DESCRIPTION
Some uses of `toBeTruthy` in tests were incorrect - this fixes them.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
