### PR TITLE
Remove default viewbox attribute and values

### DIFF
--- a/packages/icons/src/SVGBase/index.js
+++ b/packages/icons/src/SVGBase/index.js
@@ -14,7 +14,6 @@ const SVG = ({
     className={className}
     style={{ display: 'block' }}
     fill={fill}
-    viewBox="-0.2 0 17 14" // TODO: #238 why?
     {...rest}
   >
     <title>{title}</title>


### PR DESCRIPTION
Viewbox attribute should be added on a case-by-case basis and not have a default attribute which could lead to rendering issues.

Fixes  #238

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged
