### PR TITLE
Remove className as an explicit prop to the components

### DIFF
--- a/components/back-link/src/index.js
+++ b/components/back-link/src/index.js
@@ -55,8 +55,8 @@ const Anchor = styled('button')({
   },
 });
 
-const BackLink = ({ children, className, goBack }) => (
-  <Anchor className={className} onClick={goBack}>{children}</Anchor>
+const BackLink = ({ children, goBack, ...props }) => (
+  <Anchor onClick={goBack} {...props}>{children}</Anchor>
 );
 
 BackLink.propTypes = {
@@ -68,12 +68,10 @@ BackLink.propTypes = {
    * A function that is called on click
    */
   goBack: PropTypes.func, // TODO: rename onClick
-  className: PropTypes.string,
 };
 
 BackLink.defaultProps = {
   goBack: undefined,
-  className: undefined,
 };
 
 export default withWhiteSpace({ marginBottom: 3 })(BackLink);

--- a/components/breadcrumb/src/index.js
+++ b/components/breadcrumb/src/index.js
@@ -71,8 +71,8 @@ const BreadcrumbListItem = styled('li')({
 });
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const Breadcrumb = ({ children, className, ...props }) => (
-  <BreadcrumbContainer className={className} {...props}>
+const Breadcrumb = ({ children, ...props }) => (
+  <BreadcrumbContainer {...props}>
     <BreadcrumbList>
       {children.length && children.map ? (
         children.map((child, i) =>
@@ -88,16 +88,11 @@ const Breadcrumb = ({ children, className, ...props }) => (
   </BreadcrumbContainer>
 );
 
-Breadcrumb.defaultProps = {
-  className: undefined,
-};
-
 Breadcrumb.propTypes = {
   /**
    * Generally a series of anchors or Link components
    */
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 2 })(Breadcrumb);

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -62,23 +62,20 @@ const StyledButton = styled('button')(
 const Button = ({
   children,
   icon,
-  className,
   ...props
 }) => (
-  <StyledButton icon={icon} className={className} {...props}>
+  <StyledButton icon={icon} {...props}>
     {children}
     {icon}
   </StyledButton>
 );
 
 Button.propTypes = {
-  className: PropTypes.string,
   children: PropTypes.node,
   icon: PropTypes.node,
 };
 
 Button.defaultProps = {
-  className: undefined,
   children: 'Button',
   icon: undefined,
 };

--- a/components/checkbox/src/__snapshots__/test.js.snap
+++ b/components/checkbox/src/__snapshots__/test.js.snap
@@ -102,6 +102,8 @@ exports[`Checkbox matches wrapper snapshot: wrapper mount 1`] = `
 <Styled(Checkbox)>
   <Checkbox
     className="emotion-3"
+    defaultChecked={false}
+    disabled={false}
   >
     <Styled(label)
       className="emotion-3"
@@ -110,10 +112,14 @@ exports[`Checkbox matches wrapper snapshot: wrapper mount 1`] = `
         className="emotion-2"
       >
         <Styled(input)
+          defaultChecked={false}
+          disabled={false}
           type="checkbox"
         >
           <input
             className="emotion-0"
+            defaultChecked={false}
+            disabled={false}
             type="checkbox"
           />
         </Styled(input)>
@@ -234,6 +240,7 @@ exports[`Checkbox renders disabled checkbox: disabled 1`] = `
 >
   <Checkbox
     className="emotion-3"
+    defaultChecked={false}
     disabled={true}
   >
     <Styled(label)
@@ -243,11 +250,13 @@ exports[`Checkbox renders disabled checkbox: disabled 1`] = `
         className="emotion-2"
       >
         <Styled(input)
+          defaultChecked={false}
           disabled={true}
           type="checkbox"
         >
           <input
             className="emotion-0"
+            defaultChecked={false}
             disabled={true}
             type="checkbox"
           />

--- a/components/checkbox/src/index.js
+++ b/components/checkbox/src/index.js
@@ -88,23 +88,25 @@ const StyledLabel = styled('span')({
 });
 
 const Checkbox = ({
-  children, className, inline, ...input
+  children, inline, disabled, defaultChecked, ...props
 }) => (
-  <StyledCheckbox className={className} inline={inline}>
-    <StyledInput type="checkbox" {...input} />
+  <StyledCheckbox inline={inline} {...props}>
+    <StyledInput type="checkbox" disabled={disabled} defaultChecked={defaultChecked} />
     <StyledLabel>{children}</StyledLabel>
   </StyledCheckbox>
 );
 
 Checkbox.defaultProps = {
-  className: undefined,
   inline: undefined,
+  disabled: false,
+  defaultChecked: false,
 };
 
 Checkbox.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
   inline: PropTypes.bool,
+  disabled: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
 };
 
 export default withWhiteSpace({ marginBottom: 2 })(Checkbox);

--- a/components/date-input/src/index.js
+++ b/components/date-input/src/index.js
@@ -71,11 +71,11 @@ const StyledList = styled('div')({
 
 const DateInput = ({
   children,
-  className,
   errorText,
   hintText,
+  ...props
 }) => (
-  <StyledContainer className={className} errorText={errorText}>
+  <StyledContainer errorText={errorText} {...props}>
     <LabelText errorText={errorText}>{children}</LabelText>
     {hintText ? <HintText>{hintText}</HintText> : <span />}
     {errorText ? (
@@ -101,14 +101,12 @@ const DateInput = ({
 );
 
 DateInput.defaultProps = {
-  className: undefined,
   hintText: undefined,
   errorText: undefined,
 };
 
 DateInput.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
   hintText: PropTypes.string,
   errorText: PropTypes.string,
 };

--- a/components/document-footer-metadata/src/__snapshots__/test.js.snap
+++ b/components/document-footer-metadata/src/__snapshots__/test.js.snap
@@ -1,21 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Styled matches snapshot: enzyme.mount 1`] = `
-.emotion-4 {
+.emotion-1 {
   margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-4 {
+  .emotion-1 {
     margin-bottom: 0;
   }
 }
 
 .emotion-0 {
   font-family: "nta",Arial,sans-serif;
+  margin-bottom: 0;
 }
 
-.emotion-3 {
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-7 {
+  font-family: "nta",Arial,sans-serif;
+}
+
+.emotion-4 {
   margin: 0;
   padding: 0;
   padding-left: 20px;
@@ -31,25 +42,25 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-4 {
     font-size: 16px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-4 {
     margin-bottom: 0;
   }
 }
 
-.emotion-1 {
+.emotion-2 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
 }
 
-.emotion-1 > a {
+.emotion-2 > a {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -63,7 +74,7 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
   }
 >
   <DocumentFooterMetadata
-    className="emotion-4"
+    className="emotion-1"
     partOf={
       Array [
         "example",
@@ -72,14 +83,16 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
     }
   >
     <div>
-      <Styled(div)>
+      <Styled(div)
+        className="emotion-1"
+      >
         <div
           className="emotion-0"
         />
       </Styled(div)>
       <Styled(div)>
         <div
-          className="emotion-0"
+          className="emotion-7"
         >
           <div>
             <p
@@ -95,21 +108,21 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
               listStyleType="none"
             >
               <UnorderedList
-                className="emotion-4"
+                className="emotion-1"
                 listStyleType="none"
               >
                 <Styled(ul)
-                  className="emotion-4"
+                  className="emotion-1"
                   listStyleType="none"
                 >
                   <ul
-                    className="emotion-3"
+                    className="emotion-4"
                   >
                     <Styled(li)
                       key="0"
                     >
                       <li
-                        className="emotion-1"
+                        className="emotion-2"
                       >
                         example
                       </li>
@@ -118,7 +131,7 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
                       key="1"
                     >
                       <li
-                        className="emotion-1"
+                        className="emotion-2"
                       >
                         exampleexample
                       </li>
@@ -132,7 +145,7 @@ exports[`Styled matches snapshot: enzyme.mount 1`] = `
       </Styled(div)>
       <Styled(div)>
         <div
-          className="emotion-0"
+          className="emotion-7"
         />
       </Styled(div)>
     </div>

--- a/components/document-footer-metadata/src/index.js
+++ b/components/document-footer-metadata/src/index.js
@@ -20,9 +20,11 @@ const StyledDefinition = styled('li')({
   },
 });
 
-const DocumentFooterMetadata = ({ from, partOf, other }) => {
+const DocumentFooterMetadata = ({
+  from, partOf, other, ...props
+}) => {
   const fromData = (
-    <StyledContainer>
+    <StyledContainer {...props}>
       {from &&
         <div>
           <p style={{ marginBottom: 0 }}>From:</p>

--- a/components/file-upload/src/index.js
+++ b/components/file-upload/src/index.js
@@ -34,9 +34,9 @@ const StyledInput = styled('input')({
 });
 
 const FileUpload = ({
-  meta, children, hint, acceptedFormats, className,
+  meta, children, hint, acceptedFormats, ...props
 }) => (
-  <Label className={className} error={meta.error}>
+  <Label error={meta.error} {...props}>
     <LabelText error={meta.error}>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -48,7 +48,6 @@ FileUpload.defaultProps = {
   hint: undefined,
   meta: {},
   acceptedFormats: undefined,
-  className: undefined,
 };
 
 FileUpload.propTypes = {
@@ -70,7 +69,6 @@ FileUpload.propTypes = {
   }),
   children: PropTypes.node.isRequired,
   acceptedFormats: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 6 })(FileUpload);

--- a/components/input-field/src/index.js
+++ b/components/input-field/src/index.js
@@ -11,9 +11,9 @@ import Input from '@govuk-react/input';
 import { withWhiteSpace } from '@govuk-react/hoc';
 
 const InputField = ({
-  meta, children, hint, input, className,
+  meta, children, hint, input, ...props
 }) => (
-  <Label className={className} error={meta.touched && meta.error}>
+  <Label error={meta.touched && meta.error} {...props}>
     <LabelText>{children}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -25,7 +25,6 @@ InputField.defaultProps = {
   hint: null,
   input: {},
   meta: {},
-  className: undefined,
 };
 
 InputField.propTypes = {
@@ -53,7 +52,6 @@ InputField.propTypes = {
     visited: PropTypes.bool,
   }),
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(InputField);

--- a/components/label/src/index.js
+++ b/components/label/src/index.js
@@ -2,7 +2,6 @@
 
 import styled from 'react-emotion';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { ERROR_COLOUR } from 'govuk-colours';
 import { MEDIA_QUERIES, SITE_WIDTH, SPACING } from '@govuk-react/constants';
 import { withWhiteSpace } from '@govuk-react/hoc';
@@ -26,14 +25,6 @@ const StyledLabel = styled('label')(
   }),
 );
 
-const Label = ({ className, ...props }) => (<StyledLabel className={className} {...props} />);
-
-Label.defaultProps = {
-  className: undefined,
-};
-
-Label.propTypes = {
-  className: PropTypes.string,
-};
+const Label = ({ ...props }) => (<StyledLabel {...props} />);
 
 export default withWhiteSpace({ marginBottom: 0 })(Label);

--- a/components/layout/src/index.js
+++ b/components/layout/src/index.js
@@ -17,7 +17,7 @@ const StyledLayout = styled('div')({
   },
 });
 
-const Layout = ({ children }) => <StyledLayout>{children}</StyledLayout>;
+const Layout = ({ children, ...props }) => <StyledLayout {...props}>{children}</StyledLayout>;
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,

--- a/components/lead-paragraph/src/__snapshots__/test.js.snap
+++ b/components/lead-paragraph/src/__snapshots__/test.js.snap
@@ -16,6 +16,7 @@ exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
   font-size: 18px;
   line-height: 1.3;
   margin-top: 0;
+  margin-bottom: 15px;
 }
 
 @media only screen and (min-width:641px) {
@@ -25,11 +26,19 @@ exports[`Styled matches wrapper snapshot: wrapper mount 1`] = `
   }
 }
 
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 45px;
+  }
+}
+
 <Styled(LeadParagraph)>
   <LeadParagraph
     className="emotion-1"
   >
-    <Styled(p)>
+    <Styled(p)
+      className="emotion-1"
+    >
       <p
         className="emotion-0"
       >

--- a/components/lead-paragraph/src/index.js
+++ b/components/lead-paragraph/src/index.js
@@ -23,8 +23,8 @@ const StyledParagraph = styled('p')({
   },
 });
 
-const LeadParagraph = ({ children }) => (
-  <StyledParagraph>{children}</StyledParagraph>
+const LeadParagraph = ({ children, ...props }) => (
+  <StyledParagraph {...props}>{children}</StyledParagraph>
 );
 
 LeadParagraph.propTypes = {

--- a/components/list-item/src/index.js
+++ b/components/list-item/src/index.js
@@ -24,17 +24,12 @@ const StyledListItem = styled('li')({
   },
 });
 
-const ListItem = ({ children, className }) => (
-  <StyledListItem className={className}>{children}</StyledListItem>
+const ListItem = ({ children, ...props }) => (
+  <StyledListItem {...props}>{children}</StyledListItem>
 );
-
-ListItem.defaultProps = {
-  className: undefined,
-};
 
 ListItem.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(ListItem);

--- a/components/list-navigation/src/index.js
+++ b/components/list-navigation/src/index.js
@@ -7,8 +7,8 @@ import ListItem from '@govuk-react/list-item';
 import { withWhiteSpace } from '@govuk-react/hoc';
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const ListNavigation = ({ children, className, listStyleType }) => (
-  <UnorderedList className={className} listStyleType={listStyleType}>
+const ListNavigation = ({ children, listStyleType, ...props }) => (
+  <UnorderedList listStyleType={listStyleType} {...props}>
     {children.length && children.map ? (
       children.map((child, i) => (
         <ListItem key={child.key || i}>{child}</ListItem>
@@ -21,13 +21,11 @@ const ListNavigation = ({ children, className, listStyleType }) => (
 
 ListNavigation.defaultProps = {
   listStyleType: undefined,
-  className: undefined,
 };
 
 ListNavigation.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(ListNavigation);

--- a/components/loading-box/src/index.js
+++ b/components/loading-box/src/index.js
@@ -130,10 +130,9 @@ const LoadingBox = ({
   spinnerColor,
   timeIn,
   timeOut,
-  ...props
 }) => (
   <StyledContainer>
-    <CSSTransition {...props} timeout={timeOut} classNames="fade" in={loading} unmountOnExit>
+    <CSSTransition timeout={timeOut} classNames="fade" in={loading} unmountOnExit>
       <Innerwrap
         backgroundColor={backgroundColor}
         backgroundColorOpacity={backgroundColorOpacity}

--- a/components/loading-box/src/stories.js
+++ b/components/loading-box/src/stories.js
@@ -33,9 +33,7 @@ stories.add('default', () => (
       </PhaseBanner>
       {spacer}
       <Header level={2}>Toggle loading settings under `knobs`</Header>
-      <InputField
-        name="group1"
-      >
+      <InputField>
       Email address
       </InputField>
       {spacer}
@@ -60,9 +58,7 @@ stories.add('preset to loading', () => (
       </PhaseBanner>
       {spacer}
       <Header level={2}>Toggle loading settings under `knobs`</Header>
-      <InputField
-        name="group1"
-      >
+      <InputField>
       Email address
       </InputField>
       {spacer}
@@ -87,15 +83,15 @@ stories.add('LoadingBox (long)', () => (
       </PhaseBanner>
       {spacer}
       <Header level={2}>Toggle loading settings under `knobs`</Header>
-      <InputField name="group1">
+      <InputField>
         First name
       </InputField>
       {spacer}
-      <InputField name="group1">
+      <InputField>
         Last name
       </InputField>
       {spacer}
-      <InputField name="group1">
+      <InputField>
         Email address
       </InputField>
       {spacer}
@@ -110,7 +106,6 @@ stories.add('LoadingBox (long)', () => (
       </div>
       {spacer}
       <InputField
-        name="group1"
         hint="It’s on your National Insurance card"
       >
       National Insurance number

--- a/components/multi-choice/src/__snapshots__/test.js.snap
+++ b/components/multi-choice/src/__snapshots__/test.js.snap
@@ -11,6 +11,30 @@ exports[`Styled matches withError snapshot: with error mount 1`] = `
   }
 }
 
+.emotion-3 {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  box-sizing: border-box;
+  width: 100%;
+  border-left: 4px solid #b10e1e;
+  margin-right: 15px;
+  padding-left: 10px;
+  margin-bottom: 0;
+}
+
+.emotion-3:after {
+  content: '';
+  display: table;
+  clear: both;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-3 {
+    margin-bottom: 0;
+  }
+}
+
 .emotion-0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -38,27 +62,6 @@ exports[`Styled matches withError snapshot: with error mount 1`] = `
   }
 }
 
-.emotion-3 {
-  padding: 0;
-  margin: 0;
-  border: 0;
-  box-sizing: border-box;
-  width: 100%;
-  margin-bottom: 0;
-}
-
-.emotion-3:after {
-  content: '';
-  display: table;
-  clear: both;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-3 {
-    margin-bottom: 0;
-  }
-}
-
 <Styled(MultiChoice)
   error="example"
   label="example"
@@ -71,6 +74,7 @@ exports[`Styled matches withError snapshot: with error mount 1`] = `
   >
     <Styled(div)
       className="emotion-1"
+      error="example"
     >
       <div
         className="emotion-3"

--- a/components/multi-choice/src/index.js
+++ b/components/multi-choice/src/index.js
@@ -49,9 +49,9 @@ const StyledFieldset = styled('div')(
 );
 
 const MultiChoice = ({
-  meta, label, children, hint, className,
+  meta, label, children, hint, ...props
 }) => (
-  <StyledFieldset className={className} error={meta.touched && meta.error}>
+  <StyledFieldset error={meta.touched && meta.error} {...props}>
     <LabelText>{label}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -61,7 +61,6 @@ const MultiChoice = ({
 
 MultiChoice.defaultProps = {
   hint: undefined,
-  className: undefined,
   meta: {},
 };
 
@@ -84,7 +83,6 @@ MultiChoice.propTypes = {
   label: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
   hint: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(MultiChoice);

--- a/components/ordered-list/src/index.js
+++ b/components/ordered-list/src/index.js
@@ -35,21 +35,19 @@ const StyledList = styled('ol')(
 );
 
 // TODO use Context API https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
-const OrderedList = ({ children, listStyleType, className }) => (
-  <StyledList className={className} listStyleType={listStyleType}>
+const OrderedList = ({ children, listStyleType, ...props }) => (
+  <StyledList listStyleType={listStyleType} {...props}>
     {children}
   </StyledList>
 );
 
 OrderedList.defaultProps = {
   listStyleType: undefined,
-  className: undefined,
 };
 
 OrderedList.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(OrderedList);

--- a/components/pagination/src/index.js
+++ b/components/pagination/src/index.js
@@ -33,17 +33,12 @@ const StyledList = styled('ul')({
   },
 });
 
-const Pagination = ({ children, className }) => (
-  <StyledList className={className}>{children}</StyledList>
+const Pagination = ({ children, ...props }) => (
+  <StyledList {...props}>{children}</StyledList>
 );
-
-Pagination.defaultProps = {
-  className: undefined,
-};
 
 Pagination.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 6 })(Pagination);

--- a/components/phase-badge/src/index.js
+++ b/components/phase-badge/src/index.js
@@ -34,16 +34,8 @@ const StyledBadge = styled('strong')({
   },
 });
 
-const PhaseBadge = ({ className, ...props }) => (
-  <StyledBadge className={className} {...props} />
+const PhaseBadge = ({ ...props }) => (
+  <StyledBadge {...props} />
 );
-
-PhaseBadge.defaultProps = {
-  className: undefined,
-};
-
-PhaseBadge.propTypes = {
-  className: PropTypes.string,
-};
 
 export default withWhiteSpace({ marginBottom: 0 })(PhaseBadge);

--- a/components/phase-banner/src/index.js
+++ b/components/phase-banner/src/index.js
@@ -33,21 +33,16 @@ const StyledBanner = styled('div')({
   },
 });
 
-const PhaseBanner = ({ level, children, className }) => (
-  <StyledBanner className={className}>
+const PhaseBanner = ({ level, children, ...props }) => (
+  <StyledBanner {...props}>
     <PhaseBadge>{level}</PhaseBadge>
     {children}
   </StyledBanner>
 );
 
-PhaseBanner.defaultProps = {
-  className: undefined,
-};
-
 PhaseBanner.propTypes = {
   children: PropTypes.node.isRequired,
   level: PropTypes.string.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(PhaseBanner);

--- a/components/radio/src/__snapshots__/test.js.snap
+++ b/components/radio/src/__snapshots__/test.js.snap
@@ -1,24 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio disabled: disabled 1`] = `
-.emotion-1 {
+.emotion-3 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 {
     margin-bottom: 10px;
   }
 }
 
-.emotion-3 {
+.emotion-2 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   margin-right: 0px;
+  margin-bottom: 10px;
 }
 
-.emotion-2 {
+@media only screen and (min-width:641px) {
+  .emotion-2 {
+    margin-bottom: 10px;
+  }
+}
+
+.emotion-1 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -29,7 +36,7 @@ exports[`Radio disabled: disabled 1`] = `
   display: block;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -42,7 +49,7 @@ exports[`Radio disabled: disabled 1`] = `
   background: transparent;
 }
 
-.emotion-2:after {
+.emotion-1:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -66,7 +73,6 @@ exports[`Radio disabled: disabled 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: auto;
-  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -82,37 +88,37 @@ exports[`Radio disabled: disabled 1`] = `
   pointer-events: none;
 }
 
-@media only screen and (min-width:641px) {
-  .emotion-0 {
-    margin-bottom: 10px;
-  }
-}
-
 <Styled(Radio)
   disabled={true}
 >
   <Radio
-    className="emotion-1"
+    className="emotion-3"
     disabled={true}
+    input={Object {}}
+    name=""
   >
-    <Styled(label)>
+    <Styled(label)
+      className="emotion-3"
+      for=""
+    >
       <label
-        className="emotion-3"
+        className="emotion-2"
       >
         <Styled(input)
-          className="emotion-1"
           disabled={true}
+          name=""
           type="radio"
         >
           <input
             className="emotion-0"
             disabled={true}
+            name=""
             type="radio"
           />
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-2"
+            className="emotion-1"
           />
         </Styled(span)>
       </label>
@@ -122,12 +128,12 @@ exports[`Radio disabled: disabled 1`] = `
 `;
 
 exports[`Radio matches snapshot for inline: inline mount 1`] = `
-.emotion-1 {
+.emotion-3 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 {
     margin-bottom: 10px;
   }
 }
@@ -144,7 +150,6 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: pointer;
-  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -160,13 +165,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   pointer-events: auto;
 }
 
-@media only screen and (min-width:641px) {
-  .emotion-0 {
-    margin-bottom: 10px;
-  }
-}
-
-.emotion-2 {
+.emotion-1 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -177,7 +176,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   display: block;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -190,7 +189,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   background: transparent;
 }
 
-.emotion-2:after {
+.emotion-1:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -202,13 +201,20 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   opacity: 0;
 }
 
-.emotion-3 {
+.emotion-2 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   float: left;
   clear: none;
   margin-right: 30px;
+  margin-bottom: 10px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-2 {
+    margin-bottom: 10px;
+  }
 }
 
 <Styled(Radio)
@@ -216,19 +222,21 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   name="example"
 >
   <Radio
-    className="emotion-1"
+    className="emotion-3"
     disabled={false}
     inline={true}
+    input={Object {}}
     name="example"
   >
     <Styled(label)
+      className="emotion-3"
+      for="example"
       inline={true}
     >
       <label
-        className="emotion-3"
+        className="emotion-2"
       >
         <Styled(input)
-          className="emotion-1"
           disabled={false}
           name="example"
           type="radio"
@@ -242,7 +250,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-2"
+            className="emotion-1"
           >
             example
           </span>
@@ -254,21 +262,28 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
 `;
 
 exports[`Radio matches snapshot: standard mount 1`] = `
-.emotion-1 {
+.emotion-3 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-1 {
+  .emotion-3 {
     margin-bottom: 10px;
   }
 }
 
-.emotion-3 {
+.emotion-2 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   margin-right: 0px;
+  margin-bottom: 10px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-2 {
+    margin-bottom: 10px;
+  }
 }
 
 .emotion-0 {
@@ -283,7 +298,6 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: pointer;
-  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -299,13 +313,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   pointer-events: auto;
 }
 
-@media only screen and (min-width:641px) {
-  .emotion-0 {
-    margin-bottom: 10px;
-  }
-}
-
-.emotion-2 {
+.emotion-1 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -316,7 +324,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   display: block;
 }
 
-.emotion-2:before {
+.emotion-1:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -329,7 +337,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   background: transparent;
 }
 
-.emotion-2:after {
+.emotion-1:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -345,16 +353,19 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   name="example"
 >
   <Radio
-    className="emotion-1"
+    className="emotion-3"
     disabled={false}
+    input={Object {}}
     name="example"
   >
-    <Styled(label)>
+    <Styled(label)
+      className="emotion-3"
+      for="example"
+    >
       <label
-        className="emotion-3"
+        className="emotion-2"
       >
         <Styled(input)
-          className="emotion-1"
           disabled={false}
           name="example"
           type="radio"
@@ -368,7 +379,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-2"
+            className="emotion-1"
           >
             example
           </span>

--- a/components/radio/src/__snapshots__/test.js.snap
+++ b/components/radio/src/__snapshots__/test.js.snap
@@ -1,31 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio disabled: disabled 1`] = `
-.emotion-3 {
+.emotion-1 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-1 {
     margin-bottom: 10px;
   }
 }
 
-.emotion-2 {
+.emotion-3 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   margin-right: 0px;
-  margin-bottom: 10px;
 }
 
-@media only screen and (min-width:641px) {
-  .emotion-2 {
-    margin-bottom: 10px;
-  }
-}
-
-.emotion-1 {
+.emotion-2 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -36,7 +29,7 @@ exports[`Radio disabled: disabled 1`] = `
   display: block;
 }
 
-.emotion-1:before {
+.emotion-2:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -49,7 +42,7 @@ exports[`Radio disabled: disabled 1`] = `
   background: transparent;
 }
 
-.emotion-1:after {
+.emotion-2:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -73,6 +66,7 @@ exports[`Radio disabled: disabled 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: auto;
+  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -88,20 +82,25 @@ exports[`Radio disabled: disabled 1`] = `
   pointer-events: none;
 }
 
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 10px;
+  }
+}
+
 <Styled(Radio)
   disabled={true}
 >
   <Radio
-    className="emotion-3"
+    className="emotion-1"
     disabled={true}
   >
-    <Styled(label)
-      className="emotion-3"
-    >
+    <Styled(label)>
       <label
-        className="emotion-2"
+        className="emotion-3"
       >
         <Styled(input)
+          className="emotion-1"
           disabled={true}
           type="radio"
         >
@@ -113,7 +112,7 @@ exports[`Radio disabled: disabled 1`] = `
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-1"
+            className="emotion-2"
           />
         </Styled(span)>
       </label>
@@ -123,12 +122,12 @@ exports[`Radio disabled: disabled 1`] = `
 `;
 
 exports[`Radio matches snapshot for inline: inline mount 1`] = `
-.emotion-3 {
+.emotion-1 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-1 {
     margin-bottom: 10px;
   }
 }
@@ -145,6 +144,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: pointer;
+  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -160,7 +160,13 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   pointer-events: auto;
 }
 
-.emotion-1 {
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 10px;
+  }
+}
+
+.emotion-2 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -171,7 +177,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   display: block;
 }
 
-.emotion-1:before {
+.emotion-2:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -184,7 +190,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   background: transparent;
 }
 
-.emotion-1:after {
+.emotion-2:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -196,20 +202,13 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   opacity: 0;
 }
 
-.emotion-2 {
+.emotion-3 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   float: left;
   clear: none;
   margin-right: 30px;
-  margin-bottom: 10px;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-2 {
-    margin-bottom: 10px;
-  }
 }
 
 <Styled(Radio)
@@ -217,19 +216,19 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
   name="example"
 >
   <Radio
-    className="emotion-3"
+    className="emotion-1"
     disabled={false}
     inline={true}
     name="example"
   >
     <Styled(label)
-      className="emotion-3"
       inline={true}
     >
       <label
-        className="emotion-2"
+        className="emotion-3"
       >
         <Styled(input)
+          className="emotion-1"
           disabled={false}
           name="example"
           type="radio"
@@ -243,7 +242,7 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-1"
+            className="emotion-2"
           >
             example
           </span>
@@ -255,28 +254,21 @@ exports[`Radio matches snapshot for inline: inline mount 1`] = `
 `;
 
 exports[`Radio matches snapshot: standard mount 1`] = `
-.emotion-3 {
+.emotion-1 {
   margin-bottom: 10px;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-3 {
+  .emotion-1 {
     margin-bottom: 10px;
   }
 }
 
-.emotion-2 {
+.emotion-3 {
   display: block;
   position: relative;
   padding: 0 0 0 38px;
   margin-right: 0px;
-  margin-bottom: 10px;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-2 {
-    margin-bottom: 10px;
-  }
 }
 
 .emotion-0 {
@@ -291,6 +283,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   zoom: 1;
   opacity: 0;
   cursor: pointer;
+  margin-bottom: 10px;
 }
 
 .emotion-0:checked + span::after {
@@ -306,7 +299,13 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   pointer-events: auto;
 }
 
-.emotion-1 {
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 10px;
+  }
+}
+
+.emotion-2 {
   font-family: "nta",Arial,sans-serif;
   font-weight: 400;
   text-transform: none;
@@ -317,7 +316,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   display: block;
 }
 
-.emotion-1:before {
+.emotion-2:before {
   content: '';
   box-sizing: border-box;
   position: absolute;
@@ -330,7 +329,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   background: transparent;
 }
 
-.emotion-1:after {
+.emotion-2:after {
   content: '';
   position: absolute;
   top: 0.52632em;
@@ -346,17 +345,16 @@ exports[`Radio matches snapshot: standard mount 1`] = `
   name="example"
 >
   <Radio
-    className="emotion-3"
+    className="emotion-1"
     disabled={false}
     name="example"
   >
-    <Styled(label)
-      className="emotion-3"
-    >
+    <Styled(label)>
       <label
-        className="emotion-2"
+        className="emotion-3"
       >
         <Styled(input)
+          className="emotion-1"
           disabled={false}
           name="example"
           type="radio"
@@ -370,7 +368,7 @@ exports[`Radio matches snapshot: standard mount 1`] = `
         </Styled(input)>
         <Styled(span)>
           <span
-            className="emotion-1"
+            className="emotion-2"
           >
             example
           </span>

--- a/components/radio/src/index.js
+++ b/components/radio/src/index.js
@@ -84,17 +84,18 @@ const LabelText = styled('span')({
 });
 
 const Radio = ({
-  inline, children, disabled, name, input, ...props
+  inline, children, disabled, name, checked, input, ...props
 }) => (
   <Label inline={inline} for={name} {...props} >
-    <Input type="radio" disabled={disabled} name={name} {...input} />
+    <Input type="radio" checked={checked} disabled={disabled} name={name} {...input} />
     <LabelText>{children}</LabelText>
   </Label>
 );
 
 Radio.defaultProps = {
   inline: undefined,
-  disabled: false,
+  disabled: '',
+  checked: undefined,
   name: '',
   input: {},
 };
@@ -102,7 +103,8 @@ Radio.defaultProps = {
 Radio.propTypes = {
   inline: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  disabled: PropTypes.bool,
+  disabled: PropTypes.string,
+  checked: PropTypes.bool,
   name: PropTypes.string,
   input: PropTypes.shape({
     value: PropTypes.string,

--- a/components/radio/src/index.js
+++ b/components/radio/src/index.js
@@ -84,9 +84,9 @@ const LabelText = styled('span')({
 });
 
 const Radio = ({
-  inline, children, className, disabled, ...input
+  inline, children, disabled, ...input
 }) => (
-  <Label className={className} inline={inline}>
+  <Label inline={inline}>
     <Input type="radio" disabled={disabled} {...input} />
     <LabelText>{children}</LabelText>
   </Label>
@@ -94,14 +94,12 @@ const Radio = ({
 
 Radio.defaultProps = {
   inline: undefined,
-  className: undefined,
   disabled: false,
 };
 
 Radio.propTypes = {
   inline: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
   disabled: PropTypes.bool,
 };
 

--- a/components/radio/src/index.js
+++ b/components/radio/src/index.js
@@ -84,10 +84,10 @@ const LabelText = styled('span')({
 });
 
 const Radio = ({
-  inline, children, disabled, ...input
+  inline, children, disabled, name, input, ...props
 }) => (
-  <Label inline={inline}>
-    <Input type="radio" disabled={disabled} {...input} />
+  <Label inline={inline} for={name} {...props} >
+    <Input type="radio" disabled={disabled} name={name} {...input} />
     <LabelText>{children}</LabelText>
   </Label>
 );
@@ -95,12 +95,21 @@ const Radio = ({
 Radio.defaultProps = {
   inline: undefined,
   disabled: false,
+  name: '',
+  input: {},
 };
 
 Radio.propTypes = {
   inline: PropTypes.bool,
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
+  name: PropTypes.string,
+  input: PropTypes.shape({
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+    type: PropTypes.string,
+    errorColor: PropTypes.string,
+  }),
 };
 
 export default withWhiteSpace({ marginBottom: 2 })(Radio);

--- a/components/radio/src/stories.js
+++ b/components/radio/src/stories.js
@@ -35,7 +35,7 @@ RadioGroup.defaultProps = {
   meta: {},
   hint: undefined,
   inline: false,
-  options: {},
+  options: [],
 };
 
 RadioGroup.propTypes = {
@@ -44,10 +44,10 @@ RadioGroup.propTypes = {
   label: PropTypes.string.isRequired,
   hint: PropTypes.string,
   inline: PropTypes.bool,
-  options: PropTypes.shape({
+  options: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string,
     value: PropTypes.string,
-  }),
+  })),
 };
 
 storiesOf('Radio', module).add('Radio stacked', () => (
@@ -98,6 +98,7 @@ storiesOf('Radio', module).add(
   () => (
     <FinalFormWrapper>
       <Field
+        type="radio"
         name="likesAnimals"
         label="Do you like animals?"
         hint="You must tell us"

--- a/components/related-items/src/index.js
+++ b/components/related-items/src/index.js
@@ -32,17 +32,12 @@ const StyledRelatedItems = styled('div')({
   },
 });
 
-const RelatedItems = ({ children, className }) => (
-  <StyledRelatedItems className={className}>{children}</StyledRelatedItems>
+const RelatedItems = ({ children, ...props }) => (
+  <StyledRelatedItems {...props}>{children}</StyledRelatedItems>
 );
-
-RelatedItems.defaultProps = {
-  className: undefined,
-};
 
 RelatedItems.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(RelatedItems);

--- a/components/search-box/src/index.js
+++ b/components/search-box/src/index.js
@@ -62,8 +62,8 @@ const SearchButton = styled('button')({
   },
 });
 
-const SearchBox = ({ placeholder, className }) => (
-  <SearchBoxWrapper className={className}>
+const SearchBox = ({ placeholder, ...props }) => (
+  <SearchBoxWrapper {...props}>
     <InputSearchBox type="search" placeholder={placeholder} />
     <SearchButton title="Search">
       <Search fill={WHITE} />
@@ -73,12 +73,10 @@ const SearchBox = ({ placeholder, className }) => (
 
 SearchBox.defaultProps = {
   placeholder: undefined,
-  className: undefined,
 };
 
 SearchBox.propTypes = {
   placeholder: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(SearchBox);

--- a/components/select/src/__snapshots__/test.js.snap
+++ b/components/select/src/__snapshots__/test.js.snap
@@ -209,14 +209,17 @@ exports[`Select matches snapshot for errorText: errorText mount 1`] = `
     <Styled(Label)
       className="emotion-13"
       error="example"
+      errorText="example"
     >
       <Label
         className="emotion-11"
         error="example"
+        errorText="example"
       >
         <Styled(label)
           className="emotion-11"
           error="example"
+          errorText="example"
         >
           <label
             className="emotion-10"

--- a/components/select/src/index.js
+++ b/components/select/src/index.js
@@ -44,9 +44,9 @@ const StyledSelect = styled('select')(
 );
 
 const Select = ({
-  children, hint, label, meta, input, className,
+  children, hint, label, meta, input, ...props
 }) => (
-  <Label className={className} error={meta.touched && meta.error}>
+  <Label error={meta.touched && meta.error} {...props}>
     <LabelText>{label}</LabelText>
     {hint && <HintText>{hint}</HintText>}
     {meta.touched && meta.error && <ErrorText>{meta.error}</ErrorText>}
@@ -59,7 +59,6 @@ const Select = ({
 Select.defaultProps = {
   hint: undefined,
   errorText: undefined,
-  className: undefined,
   input: {},
   meta: {},
 };
@@ -91,7 +90,6 @@ Select.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
   errorText: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 6 })(Select);

--- a/components/text-area/src/__snapshots__/test.js.snap
+++ b/components/text-area/src/__snapshots__/test.js.snap
@@ -11,23 +11,6 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   }
 }
 
-.emotion-8 {
-  margin-bottom: 0;
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-8 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-8 {
-    margin-bottom: 0;
-  }
-}
-
 .emotion-0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -55,7 +38,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   }
 }
 
-.emotion-7 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -69,23 +52,16 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   margin-right: 15px;
   padding-left: 10px;
   margin-bottom: 0;
-  margin-bottom: 0;
 }
 
-.emotion-7:after {
+.emotion-8:after {
   content: '';
   display: table;
   clear: both;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-7 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-7 {
+  .emotion-8 {
     margin-bottom: 0;
   }
 }
@@ -129,6 +105,7 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
   padding: 5px 4px 4px;
   border: 2px solid #0b0c0c;
   border: 4px solid #b10e1e;
+  margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
@@ -142,6 +119,12 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
 .emotion-6:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-6 {
+    margin-bottom: 0;
+  }
 }
 
 <Styled(TextArea)
@@ -165,19 +148,18 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
     }
   >
     <Styled(Label)
-      className="emotion-1"
       error="example"
     >
       <Label
-        className="emotion-8"
+        className="emotion-1"
         error="example"
       >
         <Styled(label)
-          className="emotion-8"
+          className="emotion-1"
           error="example"
         >
           <label
-            className="emotion-7"
+            className="emotion-8"
           >
             <Styled(LabelText)>
               <LabelText
@@ -210,7 +192,10 @@ exports[`Textarea matches snapshot for error: wrapperErrorText mount 1`] = `
               </ErrorText>
             </Styled(ErrorText)>
             <Styled(textarea)
+              className="emotion-1"
               error="example"
+              errorText="example"
+              input={Object {}}
               rows="5"
               type="text"
             >
@@ -240,23 +225,6 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
 }
 
 .emotion-8 {
-  margin-bottom: 0;
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-8 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-8 {
-    margin-bottom: 0;
-  }
-}
-
-.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,23 +235,16 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
   box-sizing: border-box;
   width: 100%;
   margin-bottom: 0;
-  margin-bottom: 0;
 }
 
-.emotion-7:after {
+.emotion-8:after {
   content: '';
   display: table;
   clear: both;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-7 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-7 {
+  .emotion-8 {
     margin-bottom: 0;
   }
 }
@@ -325,6 +286,7 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
   width: 100%;
   padding: 5px 4px 4px;
   border: 2px solid #0b0c0c;
+  margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
@@ -338,6 +300,12 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
 .emotion-6:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-6 {
+    margin-bottom: 0;
+  }
 }
 
 .emotion-3 {
@@ -375,17 +343,15 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
     input={Object {}}
     meta={Object {}}
   >
-    <Styled(Label)
-      className="emotion-1"
-    >
+    <Styled(Label)>
       <Label
-        className="emotion-8"
+        className="emotion-1"
       >
         <Styled(label)
-          className="emotion-8"
+          className="emotion-1"
         >
           <label
-            className="emotion-7"
+            className="emotion-8"
           >
             <Styled(LabelText)>
               <LabelText
@@ -418,6 +384,8 @@ exports[`Textarea matches snapshot for hint: wrapperHint mount 1`] = `
               </HintText>
             </Styled(HintText)>
             <Styled(textarea)
+              className="emotion-1"
+              input={Object {}}
               rows="5"
               type="text"
             >
@@ -447,23 +415,6 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .emotion-5 {
-  margin-bottom: 0;
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-5 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-5 {
-    margin-bottom: 0;
-  }
-}
-
-.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -474,23 +425,16 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
   box-sizing: border-box;
   width: 100%;
   margin-bottom: 0;
-  margin-bottom: 0;
 }
 
-.emotion-4:after {
+.emotion-5:after {
   content: '';
   display: table;
   clear: both;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-4 {
-    margin-bottom: 0;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-4 {
+  .emotion-5 {
     margin-bottom: 0;
   }
 }
@@ -532,6 +476,7 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
   width: 100%;
   padding: 5px 4px 4px;
   border: 2px solid #0b0c0c;
+  margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
@@ -547,23 +492,27 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
   outline-offset: 0;
 }
 
+@media only screen and (min-width:641px) {
+  .emotion-3 {
+    margin-bottom: 0;
+  }
+}
+
 <Styled(TextArea)>
   <TextArea
     className="emotion-1"
     input={Object {}}
     meta={Object {}}
   >
-    <Styled(Label)
-      className="emotion-1"
-    >
+    <Styled(Label)>
       <Label
-        className="emotion-5"
+        className="emotion-1"
       >
         <Styled(label)
-          className="emotion-5"
+          className="emotion-1"
         >
           <label
-            className="emotion-4"
+            className="emotion-5"
           >
             <Styled(LabelText)>
               <LabelText
@@ -581,6 +530,8 @@ exports[`Textarea matches wrapper snapshot: wrapper mount 1`] = `
               </LabelText>
             </Styled(LabelText)>
             <Styled(textarea)
+              className="emotion-1"
+              input={Object {}}
               rows="5"
               type="text"
             >

--- a/components/text-area/src/index.js
+++ b/components/text-area/src/index.js
@@ -43,31 +43,31 @@ const TextAreaField = styled('textarea')(
   }),
 );
 
-const TextArea = ({ className, ...props }) => (
-  <Label className={className} error={props.meta.touched && props.meta.error}>
-    <LabelText>{props.children}</LabelText>
-    {props.hint && <HintText>{props.hint}</HintText>}
-    {props.meta.touched &&
-      props.meta.error && <ErrorText>{props.meta.error}</ErrorText>}
+const TextArea = ({
+  children, hint, meta, ...input
+}) => (
+  <Label error={meta.touched && meta.error}>
+    <LabelText>{children}</LabelText>
+    {hint && <HintText>{hint}</HintText>}
+    {meta.touched &&
+      meta.error && <ErrorText>{meta.error}</ErrorText>}
     <TextAreaField
       type="text"
       rows="5"
-      error={props.meta.touched && props.meta.error}
-      {...props.input}
+      error={meta.touched && meta.error}
+      {...input}
     />
   </Label>
 );
 
 TextArea.defaultProps = {
   hint: undefined,
-  className: undefined,
   input: {},
   meta: {},
 };
 
 TextArea.propTypes = {
   hint: PropTypes.string,
-  className: PropTypes.string,
   input: PropTypes.shape({
     name: PropTypes.string,
     onBlur: PropTypes.func,

--- a/components/unordered-list/src/index.js
+++ b/components/unordered-list/src/index.js
@@ -38,19 +38,17 @@ const StyledList = styled('ul')(
 
 // listStyleType: normal HTML property values are used here
 // e.g., listStyleType="circle", listStyleType="upper-alpha", listStyleType="none"
-const UnorderedList = ({ children, listStyleType, className }) => (
-  <StyledList className={className} listStyleType={listStyleType}>{children}</StyledList>
+const UnorderedList = ({ children, listStyleType, ...props }) => (
+  <StyledList listStyleType={listStyleType} {...props}>{children}</StyledList>
 );
 
 UnorderedList.defaultProps = {
   listStyleType: undefined,
-  className: undefined,
 };
 
 UnorderedList.propTypes = {
   children: PropTypes.node.isRequired,
   listStyleType: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default withWhiteSpace({ marginBottom: 0 })(UnorderedList);


### PR DESCRIPTION
# Remove className as an explicit prop to the components
* The className prop can now be passed in using the spreadOperator …props instead if necessary
* Snapshots have been updated 

**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

closes  #267 